### PR TITLE
Support custom name in source sets

### DIFF
--- a/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/Constants.kt
+++ b/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/Constants.kt
@@ -1,6 +1,3 @@
 package com.varabyte.kobweb.gradle.application
 
 const val GENERATED_ROOT = "generated/kobweb"
-const val JS_SRC_SUFFIX = "/src/jsMain/kotlin"
-const val JS_RESOURCE_SUFFIX = "/src/jsMain/resources"
-const val JVM_SRC_SUFFIX = "/src/jvmMain/kotlin"

--- a/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/extensions/GradleExtensions.kt
+++ b/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/extensions/GradleExtensions.kt
@@ -1,37 +1,26 @@
 package com.varabyte.kobweb.gradle.application.extensions
 
+import com.varabyte.kobweb.gradle.application.kmp.TargetPlatform
 import com.varabyte.kobweb.gradle.application.kmp.kotlin
 import org.gradle.api.Project
 import org.gradle.api.file.SourceDirectorySet
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import java.io.File
 
-enum class TargetPlatform {
-    JS,
-    JVM,
-}
-
-private fun TargetPlatform.toSourceSetName(): String {
-    return when (this) {
-        TargetPlatform.JS -> "jsMain"
-        TargetPlatform.JVM -> "jvmMain"
-    }
-}
-
 private fun Project.getRoots(
-    platform: TargetPlatform,
+    platform: TargetPlatform<*>,
     sourceSetToDirSet: (KotlinSourceSet) -> SourceDirectorySet
 ): Sequence<File> {
     return project.kotlin.sourceSets.asSequence()
-        .filter { sourceSet -> sourceSet.name == platform.toSourceSetName() }
+        .filter { sourceSet -> sourceSet.name == platform.mainSourceSet }
         .flatMap { sourceSet -> sourceSetToDirSet(sourceSet).srcDirs }
 }
 
-fun Project.getSourceRoots(platform: TargetPlatform): Sequence<File> {
+fun Project.getSourceRoots(platform: TargetPlatform<*>): Sequence<File> {
     return project.getRoots(platform) { sourceSet -> sourceSet.kotlin }
 }
 
-fun Project.getResourceRoots(platform: TargetPlatform): Sequence<File> =
+fun Project.getResourceRoots(platform: TargetPlatform<*>): Sequence<File> =
     project.getRoots(platform) { sourceSet -> sourceSet.resources }
 
 class RootAndFile(val root: File, val file: File) {
@@ -39,7 +28,7 @@ class RootAndFile(val root: File, val file: File) {
 }
 
 private fun Project.getFilesWithRoots(
-    platform: TargetPlatform,
+    platform: TargetPlatform<*>,
     sourceSetToDirSet: (KotlinSourceSet) -> SourceDirectorySet
 ): Sequence<RootAndFile> {
     return project.getRoots(platform, sourceSetToDirSet)
@@ -50,20 +39,20 @@ private fun Project.getFilesWithRoots(
         }
 }
 
-fun Project.getSourceFilesWithRoots(platform: TargetPlatform): Sequence<RootAndFile> {
+fun Project.getSourceFilesWithRoots(platform: TargetPlatform<*>): Sequence<RootAndFile> {
     return project.getFilesWithRoots(platform) { sourceSet -> sourceSet.kotlin }
         .filter { it.file.extension == "kt" }
 }
 
-fun Project.getResourceFilesWithRoots(platform: TargetPlatform): Sequence<RootAndFile> {
+fun Project.getResourceFilesWithRoots(platform: TargetPlatform<*>): Sequence<RootAndFile> {
     return project.getFilesWithRoots(platform) { sourceSet -> sourceSet.resources }
 }
 
-fun Project.getSourceFiles(platform: TargetPlatform): Sequence<File> {
+fun Project.getSourceFiles(platform: TargetPlatform<*>): Sequence<File> {
     return project.getSourceFilesWithRoots(platform).map { it.file }
 }
 
-fun Project.getResourceFiles(platform: TargetPlatform): Sequence<File> {
+fun Project.getResourceFiles(platform: TargetPlatform<*>): Sequence<File> {
     return project.getResourceFilesWithRoots(platform).map { it.file }
 }
 

--- a/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/extensions/KobwebBlock.kt
+++ b/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/extensions/KobwebBlock.kt
@@ -4,9 +4,8 @@ package com.varabyte.kobweb.gradle.application.extensions
 
 import com.varabyte.kobweb.common.navigation.RoutePrefix
 import com.varabyte.kobweb.gradle.application.GENERATED_ROOT
-import com.varabyte.kobweb.gradle.application.JS_RESOURCE_SUFFIX
-import com.varabyte.kobweb.gradle.application.JS_SRC_SUFFIX
-import com.varabyte.kobweb.gradle.application.JVM_SRC_SUFFIX
+import com.varabyte.kobweb.gradle.application.kmp.jsTarget
+import com.varabyte.kobweb.gradle.application.kmp.jvmTarget
 import com.varabyte.kobweb.project.conf.KobwebConf
 import kotlinx.html.HEAD
 import kotlinx.html.link
@@ -104,14 +103,20 @@ abstract class KobwebBlock @Inject constructor(conf: KobwebConf) {
         (this as ExtensionAware).extensions.create("index", IndexDocument::class.java, RoutePrefix(conf.site.routePrefix))
     }
 
-    fun getGenJsSrcRoot(project: Project): File =
-        project.layout.buildDirectory.dir("${genDir.get()}$JS_SRC_SUFFIX").get().asFile
+    fun getGenJsSrcRoot(project: Project): File {
+        val jsSrcSuffix = project.jsTarget.srcSuffix
+        return project.layout.buildDirectory.dir("${genDir.get()}$jsSrcSuffix").get().asFile
+    }
 
-    fun getGenJsResRoot(project: Project): File =
-        project.layout.buildDirectory.dir("${genDir.get()}$JS_RESOURCE_SUFFIX").get().asFile
+    fun getGenJsResRoot(project: Project): File {
+        val jsResourceSuffix = project.jsTarget.resourceSuffix
+        return project.layout.buildDirectory.dir("${genDir.get()}$jsResourceSuffix").get().asFile
+    }
 
-    fun getGenJvmSrcRoot(project: Project): File =
-        project.layout.buildDirectory.dir("${genDir.get()}$JVM_SRC_SUFFIX").get().asFile
+    fun getGenJvmSrcRoot(project: Project): File {
+        val jvmSrcSuffix = (project.jvmTarget ?: error("No JVM target defined")).srcSuffix
+        return project.layout.buildDirectory.dir("${genDir.get()}$jvmSrcSuffix").get().asFile
+    }
 }
 
 val KobwebBlock.index: KobwebBlock.IndexDocument

--- a/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/kmp/MultiplatformExtensions.kt
+++ b/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/kmp/MultiplatformExtensions.kt
@@ -3,11 +3,16 @@
 package com.varabyte.kobweb.gradle.application.kmp
 
 import org.gradle.api.Action
+import org.gradle.api.NamedDomainObjectCollection
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionAware
+import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
+import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
+import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrTarget
+import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
 
 val Project.kotlin get() = extensions.getByName("kotlin") as KotlinMultiplatformExtension
 
@@ -16,3 +21,6 @@ fun Project.kotlin(configure: Action<KotlinMultiplatformExtension>): Unit =
 
 fun KotlinMultiplatformExtension.sourceSets(configure: Action<NamedDomainObjectContainer<KotlinSourceSet>>): Unit =
     (this as ExtensionAware).extensions.configure("sourceSets", configure)
+
+val Project.buildTargets: NamedDomainObjectCollection<KotlinTarget>
+    get() = kotlin.targets

--- a/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/kmp/TargetPlatform.kt
+++ b/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/kmp/TargetPlatform.kt
@@ -1,0 +1,47 @@
+package com.varabyte.kobweb.gradle.application.kmp
+
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
+import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrTarget
+import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
+
+interface TargetPlatform<T : KotlinTarget> {
+    val name: String
+
+    val mainSourceSet: String get() = "${name}Main"
+    val srcSuffix: String get() = "/src/${mainSourceSet}/kotlin"
+    val resourceSuffix: String get() = "/src/${mainSourceSet}/resources"
+
+    val compileKotlin: String
+}
+
+class JsTarget(private val target: KotlinJsIrTarget) : TargetPlatform<KotlinJsIrTarget> {
+    override val name: String = target.name
+
+    val browserDevelopmentRun by lazy { "${target.name}BrowserDevelopmentRun" }
+    val browserProductionRun by lazy { "${target.name}BrowserProductionRun" }
+    val browserRun by lazy { "${target.name}BrowserRun" }
+    val run by lazy { "${target.name}Run" }
+
+    override val compileKotlin by lazy { "compileKotlin${target.name.capitalize()}" }
+    val processResources by lazy { "${target.name}ProcessResources" }
+
+    val developmentExecutableCompileSync by lazy { "${target.name}DevelopmentExecutableCompileSync" }
+    val productionExecutableCompileSync by lazy { "${target.name}ProductionExecutableCompileSync" }
+}
+
+val Project.jsTarget: JsTarget
+    get() = JsTarget(buildTargets.withType<KotlinJsIrTarget>().single())
+
+
+class JvmTarget(private val target: KotlinJvmTarget) : TargetPlatform<KotlinJvmTarget> {
+    override val name: String = target.name
+
+    override val compileKotlin by lazy { "compileKotlin${target.name.capitalize()}" }
+
+    val jar by lazy { "${target.name}Jar" }
+}
+
+val Project.jvmTarget: JvmTarget?
+    get() = buildTargets.withType<KotlinJvmTarget>().singleOrNull()?.run(::JvmTarget)

--- a/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebProjectTask.kt
+++ b/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebProjectTask.kt
@@ -4,10 +4,13 @@ package com.varabyte.kobweb.gradle.application.tasks
 
 import com.varabyte.kobweb.gradle.application.extensions.KobwebBlock
 import com.varabyte.kobweb.gradle.application.extensions.RootAndFile
-import com.varabyte.kobweb.gradle.application.extensions.TargetPlatform
 import com.varabyte.kobweb.gradle.application.extensions.getBuildScripts
 import com.varabyte.kobweb.gradle.application.extensions.getResourceFilesWithRoots
 import com.varabyte.kobweb.gradle.application.extensions.getSourceFiles
+import com.varabyte.kobweb.gradle.application.kmp.JsTarget
+import com.varabyte.kobweb.gradle.application.kmp.JvmTarget
+import com.varabyte.kobweb.gradle.application.kmp.jsTarget
+import com.varabyte.kobweb.gradle.application.kmp.jvmTarget
 import com.varabyte.kobweb.project.conf.KobwebConfFile
 import com.varabyte.kobweb.server.api.ServerState
 import org.gradle.api.GradleException
@@ -40,13 +43,14 @@ abstract class KobwebProjectTask(@get:Internal val kobwebBlock: KobwebBlock, des
     fun getBuildScripts(): List<File> = project.getBuildScripts().toList()
 
     @Internal
-    protected fun getSourceFilesJs(): List<File> = project.getSourceFiles(TargetPlatform.JS).toList()
+    protected fun getSourceFilesJs(): List<File> = project.getSourceFiles(project.jsTarget).toList()
 
     @Internal
-    protected fun getSourceFilesJvm(): List<File> = project.getSourceFiles(TargetPlatform.JVM).toList()
+    protected fun getSourceFilesJvm(): List<File> =
+        project.jvmTarget?.let { project.getSourceFiles(it).toList() } ?: emptyList()
 
     @Internal
-    fun getResourceFilesJsWithRoots(): Sequence<RootAndFile> = project.getResourceFilesWithRoots(TargetPlatform.JS)
+    fun getResourceFilesJsWithRoots(): Sequence<RootAndFile> = project.getResourceFilesWithRoots(project.jsTarget)
         .filter { rootAndFile -> rootAndFile.relativeFile.path.startsWith("${getPublicPath()}/") }
 
     @Internal

--- a/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/tasks/ConvertMarkdownTask.kt
+++ b/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/tasks/ConvertMarkdownTask.kt
@@ -4,10 +4,10 @@ import com.varabyte.kobweb.common.packageConcat
 import com.varabyte.kobweb.common.toPackageName
 import com.varabyte.kobweb.gradle.application.extensions.KobwebBlock
 import com.varabyte.kobweb.gradle.application.extensions.RootAndFile
-import com.varabyte.kobweb.gradle.application.extensions.TargetPlatform
 import com.varabyte.kobweb.gradle.application.extensions.getResourceFilesWithRoots
 import com.varabyte.kobweb.gradle.application.extensions.getResourceRoots
 import com.varabyte.kobweb.gradle.application.extensions.prefixQualifiedPackage
+import com.varabyte.kobweb.gradle.application.kmp.jsTarget
 import com.varabyte.kobwebx.gradle.markdown.KotlinRenderer
 import com.varabyte.kobwebx.gradle.markdown.MarkdownComponents
 import com.varabyte.kobwebx.gradle.markdown.MarkdownConfig
@@ -33,12 +33,12 @@ abstract class ConvertMarkdownTask @Inject constructor(
     private val markdownFeatures =
         (markdownConfig as ExtensionAware).extensions.getByName("features") as MarkdownFeatures
 
-    private fun getMarkdownRoots(): Sequence<File> = project.getResourceRoots(TargetPlatform.JS)
+    private fun getMarkdownRoots(): Sequence<File> = project.getResourceRoots(project.jsTarget)
         .map { root -> File(root, markdownConfig.markdownPath.get()) }
 
     private fun getMarkdownFilesWithRoots(): List<RootAndFile> {
         val mdRoots = getMarkdownRoots()
-        return project.getResourceFilesWithRoots(TargetPlatform.JS)
+        return project.getResourceFilesWithRoots(project.jsTarget)
             .filter { rootAndFile -> rootAndFile.file.extension == "md" }
             .mapNotNull { rootAndFile ->
                 mdRoots.find { mdRoot -> rootAndFile.file.startsWith(mdRoot) }


### PR DESCRIPTION
In Kotlin Multiplatform is it possible to change the default source set
name (like `js` or `jvm`) to a custom one

This commit replaces all hardcoded task names and source set references
with its corresponding exact values

Fixes #150