### PR TITLE
Add support for responding to stream exceptions

### DIFF
--- a/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/stream/StreamSupport.kt
+++ b/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/stream/StreamSupport.kt
@@ -54,8 +54,9 @@ value class StreamClientId private constructor(val id: Short) {
         // wrapping around is fine to guarantee uniqueness.
         fun next() = StreamClientId((nextId.getAndIncrement() % Short.MAX_VALUE).toShort())
     }
-}
 
+    override fun toString() = id.toString()
+}
 
 /**
  * A single event associated with the stream between the client and this server.

--- a/common/client-server-models/src/commonMain/kotlin/com/varabyte/kobweb/streams/StreamMessage.kt
+++ b/common/client-server-models/src/commonMain/kotlin/com/varabyte/kobweb/streams/StreamMessage.kt
@@ -7,28 +7,51 @@ import kotlinx.serialization.Serializable
  * A message sent from the client to the server, to deliver a payload to a target API stream.
  */
 @Serializable
-class StreamMessage(
-    val route: String,
-    val payload: Payload,
-) {
+class StreamMessage<out P : StreamMessage.Payload>(val route: String, val payload: P) {
     @Serializable
     sealed interface Payload {
+        /**
+         * Payloads that are sent from the client to the server.
+         */
         @Serializable
-        @SerialName("StreamPayloadClientConnect")
-        object ClientConnect : Payload
+        sealed interface Client : Payload {
+            @Serializable
+            @SerialName("StreamPayloadClientConnect")
+            object Connect : Client
 
+            @Serializable
+            @SerialName("StreamPayloadClientDisconnect")
+            object Disconnect : Client
+        }
+
+        /**
+         * Payloads that are sent from the server to the client.
+         */
         @Serializable
-        @SerialName("StreamPayloadClientDisconnect")
-        object ClientDisconnect : Payload
+        sealed interface Server : Payload {
+            /**
+             * @param callstack The callstack of the error from the server. This will only get sent by servers in dev mode.
+             *   If in release, you'll need to check the logs instead to see what happened.
+             */
+            @Serializable
+            @SerialName("StreamPayloadServerError")
+            class Error(val callstack: String?) : Server
+        }
+
+        /** Payloads that can be sent in either direction. */
+        @Serializable
+        sealed interface Bidirectional : Client, Server
 
         @Serializable
         @SerialName("StreamPayloadText")
-        class Text(val text: String) : Payload
+        class Text(val text: String) : Bidirectional
     }
 
     companion object {
-        fun clientConnect(route: String) = StreamMessage(route, Payload.ClientConnect)
-        fun clientDisconnect(route: String) = StreamMessage(route, Payload.ClientDisconnect)
-        fun text(route: String, text: String) = StreamMessage(route, Payload.Text(text))
+        fun clientConnect(route: String) = StreamMessage<Payload.Client>(route, Payload.Client.Connect)
+        fun clientDisconnect(route: String) = StreamMessage<Payload.Client>(route, Payload.Client.Disconnect)
+        fun text(route: String, text: String) = StreamMessage<Payload.Bidirectional>(route, Payload.Text(text))
+        fun serverError(route: String, callstack: String?) =
+            StreamMessage<Payload.Server>(route, Payload.Server.Error(callstack))
     }
 }


### PR DESCRIPTION
If an API stream server endpoint crashes, this now does the following:

* Notifies the user via an onError callback
* Sends a message informing the client (with callstack when in dev mode)
* Disconnects the stream (unless the user prevents that in the onError callback)