### PR TITLE
Use interfaces for layout scopes

### DIFF
--- a/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/foundation/layout/Box.kt
+++ b/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/foundation/layout/Box.kt
@@ -11,11 +11,13 @@ import com.varabyte.kobweb.compose.ui.toAttrs
 import org.jetbrains.compose.web.dom.Div
 import org.w3c.dom.HTMLElement
 
-class BoxScope {
+interface BoxScope {
     fun Modifier.align(alignment: Alignment) = attrsModifier {
         classes("${alignment.toClassName()}-self")
     }
 }
+
+internal object BoxScopeInstance : BoxScope
 
 @Composable
 fun Box(
@@ -28,6 +30,6 @@ fun Box(
         classes("kobweb-box", contentAlignment.toClassName())
     }) {
         registerRefScope(ref)
-        BoxScope().content()
+        BoxScopeInstance.content()
     }
 }

--- a/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/foundation/layout/Column.kt
+++ b/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/foundation/layout/Column.kt
@@ -7,19 +7,17 @@ import com.varabyte.kobweb.compose.style.toClassName
 import com.varabyte.kobweb.compose.ui.Alignment
 import com.varabyte.kobweb.compose.ui.Modifier
 import com.varabyte.kobweb.compose.ui.attrsModifier
-import com.varabyte.kobweb.compose.ui.modifiers.*
 import com.varabyte.kobweb.compose.ui.toAttrs
 import org.jetbrains.compose.web.dom.Div
 import org.w3c.dom.HTMLElement
 
-class ColumnScope {
+interface ColumnScope : FlexScope {
     fun Modifier.align(alignment: Alignment.Horizontal) = attrsModifier {
         classes("${alignment.toClassName()}-self")
     }
-
-    // Convenient remapping to "flexGrow" for users coming from the world of Android
-    fun Modifier.weight(value: Number) = this.flexGrow(value)
 }
+
+internal object ColumnScopeInstance : ColumnScope
 
 @Composable
 fun Column(
@@ -33,6 +31,6 @@ fun Column(
         classes("kobweb-col", verticalArrangement.toClassName(), horizontalAlignment.toClassName())
     }) {
         registerRefScope(ref)
-        ColumnScope().content()
+        ColumnScopeInstance.content()
     }
 }

--- a/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/foundation/layout/FlexScope.kt
+++ b/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/foundation/layout/FlexScope.kt
@@ -1,0 +1,9 @@
+package com.varabyte.kobweb.compose.foundation.layout
+
+import com.varabyte.kobweb.compose.ui.Modifier
+import com.varabyte.kobweb.compose.ui.modifiers.*
+
+interface FlexScope {
+    // Convenient remapping to "flexGrow" for users coming from the world of Android
+    fun Modifier.weight(value: Number) = this.flexGrow(value)
+}

--- a/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/foundation/layout/Row.kt
+++ b/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/foundation/layout/Row.kt
@@ -7,19 +7,17 @@ import com.varabyte.kobweb.compose.style.toClassName
 import com.varabyte.kobweb.compose.ui.Alignment
 import com.varabyte.kobweb.compose.ui.Modifier
 import com.varabyte.kobweb.compose.ui.attrsModifier
-import com.varabyte.kobweb.compose.ui.modifiers.*
 import com.varabyte.kobweb.compose.ui.toAttrs
 import org.jetbrains.compose.web.dom.Div
 import org.w3c.dom.HTMLElement
 
-class RowScope {
+interface RowScope : FlexScope {
     fun Modifier.align(alignment: Alignment.Vertical) = attrsModifier {
         classes("${alignment.toClassName()}-self")
     }
-
-    // Convenient remapping to "flexGrow" for users coming from the world of Android
-    fun Modifier.weight(value: Number) = this.flexGrow(value)
 }
+
+internal object RowScopeInstance : RowScope
 
 @Composable
 fun Row(
@@ -33,6 +31,6 @@ fun Row(
         classes("kobweb-row", horizontalArrangement.toClassName(), verticalAlignment.toClassName())
     }) {
         registerRefScope(ref)
-        RowScope().content()
+        RowScopeInstance.content()
     }
 }

--- a/frontend/kobweb-silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/overlay/Popup.kt
+++ b/frontend/kobweb-silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/overlay/Popup.kt
@@ -6,7 +6,6 @@ import com.varabyte.kobweb.compose.dom.ElementRefScope
 import com.varabyte.kobweb.compose.dom.ElementTarget
 import com.varabyte.kobweb.compose.dom.observers.ResizeObserver
 import com.varabyte.kobweb.compose.foundation.layout.BoxScope
-import com.varabyte.kobweb.compose.ui.Alignment
 import com.varabyte.kobweb.compose.ui.Modifier
 import com.varabyte.kobweb.compose.ui.modifiers.*
 import com.varabyte.kobweb.silk.components.style.ComponentStyle
@@ -68,9 +67,7 @@ enum class PopupPlacement {
  *
  * Note that this is essentially a [BoxScope] with some extra information added to it relevant to popups.
  */
-class PopupScope(val placement: PopupPlacement?) {
-    fun Modifier.align(alignment: Alignment) = with(BoxScope()) { align(alignment) }
-}
+class PopupScope(val placement: PopupPlacement?) : BoxScope
 
 private fun HTMLElement.updatePosition(position: PopupPlacementStrategy.Position) {
     style.top = "${position.top}"


### PR DESCRIPTION
This makes it easier to provide extended versions of scopes (like `PopupScope`) and also makes the implementation consistent with Jetpack Compose.