### PR TITLE
Group Silk color variables into a style

### DIFF
--- a/frontend/kobweb-silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/init/InitSilk.kt
+++ b/frontend/kobweb-silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/init/InitSilk.kt
@@ -1,7 +1,8 @@
 package com.varabyte.kobweb.silk.init
 
 import androidx.compose.runtime.*
-import com.varabyte.kobweb.compose.css.*
+import com.varabyte.kobweb.compose.ui.Modifier
+import com.varabyte.kobweb.compose.ui.modifiers.*
 import com.varabyte.kobweb.silk.SilkStyleSheet
 import com.varabyte.kobweb.silk.components.disclosure.TabBackgroundColorVar
 import com.varabyte.kobweb.silk.components.disclosure.TabBorderColorVar
@@ -71,6 +72,8 @@ import com.varabyte.kobweb.silk.components.overlay.TooltipTextContainerStyle
 import com.varabyte.kobweb.silk.components.overlay.TopLeftTooltipArrowVariant
 import com.varabyte.kobweb.silk.components.overlay.TopRightTooltipArrowVariant
 import com.varabyte.kobweb.silk.components.overlay.TopTooltipArrowVariant
+import com.varabyte.kobweb.silk.components.style.ComponentStyle
+import com.varabyte.kobweb.silk.components.style.base
 import com.varabyte.kobweb.silk.components.style.common.DisabledStyle
 import com.varabyte.kobweb.silk.components.style.common.SmoothColorStyle
 import com.varabyte.kobweb.silk.components.text.DivTextStyle
@@ -83,7 +86,10 @@ import com.varabyte.kobweb.silk.theme.colors.BackgroundColorVar
 import com.varabyte.kobweb.silk.theme.colors.BorderColorVar
 import com.varabyte.kobweb.silk.theme.colors.ColorMode
 import com.varabyte.kobweb.silk.theme.colors.ColorVar
+import com.varabyte.kobweb.silk.theme.colors.suffixedWith
 import com.varabyte.kobweb.silk.theme.toSilkPalette
+import kotlinx.dom.addClass
+import kotlinx.dom.removeClass
 import org.w3c.dom.HTMLElement
 
 /**
@@ -99,6 +105,8 @@ class InitSilkContext(val config: MutableSilkConfig, val stylesheet: SilkStylesh
 
 fun initSilk(additionalInit: (InitSilkContext) -> Unit = {}) {
     val mutableTheme = MutableSilkTheme()
+
+    mutableTheme.registerComponentStyle(SilkColorsStyle)
 
     // TODO: Automate the creation of this list (with a Gradle task?)
     mutableTheme.registerComponentStyle(ButtonStyle)
@@ -167,49 +175,54 @@ fun initSilk(additionalInit: (InitSilkContext) -> Unit = {}) {
     SilkTheme.registerStyles(SilkStyleSheet)
 }
 
+private val SilkColorsStyle by ComponentStyle.base {
+    val palette = colorMode.toSilkPalette()
+    Modifier
+    // region General color vars
+        .setVariable(BackgroundColorVar, palette.background)
+        .setVariable(ColorVar, palette.color)
+        .setVariable(BorderColorVar, palette.border)
+    // endregion
+
+    // region Widget color vars
+        .setVariable(ButtonBackgroundDefaultColorVar, palette.button.default)
+        .setVariable(ButtonBackgroundFocusColorVar, palette.button.focus)
+        .setVariable(ButtonBackgroundHoverColorVar, palette.button.hover)
+        .setVariable(ButtonBackgroundPressedColorVar, palette.button.pressed)
+        .setVariable(ButtonColorVar, palette.color)
+
+        .setVariable(DividerColorVar, palette.border)
+
+        .setVariable(LinkDefaultColorVar, palette.link.default)
+        .setVariable(LinkVisitedColorVar, palette.link.visited)
+
+        .setVariable(OverlayBackgroundColorVar, palette.overlay)
+
+        .setVariable(SurfaceBackgroundColorVar, palette.background)
+        .setVariable(SurfaceColorVar, palette.color)
+
+        .setVariable(SwitchThumbColorVar, palette.switch.thumb)
+
+        .setVariable(TabColorVar, palette.tab.color)
+        .setVariable(TabBackgroundColorVar, palette.tab.background)
+        .setVariable(TabBorderColorVar, palette.tab.border)
+        .setVariable(TabDisabledBackgroundColorVar, palette.tab.disabled)
+        .setVariable(TabHoverBackgroundColorVar, palette.tab.hover)
+        .setVariable(TabPressedBackgroundColorVar, palette.tab.pressed)
+
+        .setVariable(TocBorderColorVar, palette.border)
+
+        .setVariable(TooltipBackgroundColorVar, palette.tooltip.background)
+        .setVariable(TooltipColorVar, palette.tooltip.color)
+    // endregion
+}
+
 @Composable
 fun HTMLElement.setSilkVariables() {
     setSilkVariables(ColorMode.current)
 }
 
 fun HTMLElement.setSilkVariables(colorMode: ColorMode) {
-    val palette = colorMode.toSilkPalette()
-
-    // region General color vars
-    setVariable(BackgroundColorVar, palette.background)
-    setVariable(ColorVar, palette.color)
-    setVariable(BorderColorVar, palette.border)
-    // endregion
-
-    // region Widget color vars
-    setVariable(ButtonBackgroundDefaultColorVar, palette.button.default)
-    setVariable(ButtonBackgroundFocusColorVar, palette.button.focus)
-    setVariable(ButtonBackgroundHoverColorVar, palette.button.hover)
-    setVariable(ButtonBackgroundPressedColorVar, palette.button.pressed)
-    setVariable(ButtonColorVar, palette.color)
-
-    setVariable(DividerColorVar, palette.border)
-
-    setVariable(LinkDefaultColorVar, palette.link.default)
-    setVariable(LinkVisitedColorVar, palette.link.visited)
-
-    setVariable(OverlayBackgroundColorVar, palette.overlay)
-
-    setVariable(SurfaceBackgroundColorVar, palette.background)
-    setVariable(SurfaceColorVar, palette.color)
-
-    setVariable(SwitchThumbColorVar, palette.switch.thumb)
-
-    setVariable(TabColorVar, palette.tab.color)
-    setVariable(TabBackgroundColorVar, palette.tab.background)
-    setVariable(TabBorderColorVar, palette.tab.border)
-    setVariable(TabDisabledBackgroundColorVar, palette.tab.disabled)
-    setVariable(TabHoverBackgroundColorVar, palette.tab.hover)
-    setVariable(TabPressedBackgroundColorVar, palette.tab.pressed)
-
-    setVariable(TocBorderColorVar, palette.border)
-
-    setVariable(TooltipBackgroundColorVar, palette.tooltip.background)
-    setVariable(TooltipColorVar, palette.tooltip.color)
-    // endregion
+    removeClass(SilkColorsStyle.name.suffixedWith(colorMode.opposite))
+    addClass(SilkColorsStyle.name.suffixedWith(colorMode))
 }


### PR DESCRIPTION
This means that elements now just look something like:

```
<div class="silk-colors_light" />
```

instead of

```
<div style="--silk-background-color: ...; --silk-color: ...; ..." />
```

with a growing list that already has dozens of colors.