### PR TITLE
Switch to using `@Api` annotation to specify `routeOverride` for api streams

### DIFF
--- a/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/Api.kt
+++ b/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/Api.kt
@@ -40,5 +40,5 @@ package com.varabyte.kobweb.api
  * @param routeOverride If specified, override the logic for generating a route for this API as documented in this
  *   header doc.
  */
-@Target(AnnotationTarget.FUNCTION)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
 annotation class Api(val routeOverride: String = "")


### PR DESCRIPTION
This is useful to guarantee compile-time access & necessary for upcoming switch to KSP. Note that this preserves backwards-compatibility for those specifying the override as a parameter.

TODO: Update kdoc for `@Api`