### PR TITLE
Replace links to .md files in Markdown with their generated counterparts

### DIFF
--- a/playground/site/src/jsMain/resources/markdown/KotlinLanguage.md
+++ b/playground/site/src/jsMain/resources/markdown/KotlinLanguage.md
@@ -1,0 +1,8 @@
+---
+root: .components.layouts.PageLayout("KOTLIN")
+routeOverride: languages/kotlin
+---
+
+Concise. Cross‑platform. Fun.
+
+<https://kotlinlang.org>

--- a/playground/site/src/jsMain/resources/markdown/Markdown.md
+++ b/playground/site/src/jsMain/resources/markdown/Markdown.md
@@ -6,7 +6,7 @@ root: .components.layouts.PageLayout("MARKDOWN")
 
 This is [an example][id] reference-style link.
 
-This site is generated from markdown.
+This site is generated from Markdown.
 
 Create rich, dynamic web apps with ease, leveraging [Kotlin](https://kotlinlang.org/) and [Compose HTML](https://github.com/JetBrains/compose-multiplatform#compose-html).
 
@@ -36,6 +36,12 @@ You can use blockquotes:
 > The trouble with quotes on the internet is you never know if they are genuine.
 >
 > -- Abraham Lincoln
+
+You can link to other Markdown documents with their route overrides resolved correctly (except for dynamic overrides):
+
+[documents/INDEX.md](documents/INDEX.md)<br>
+[KotlinLanguage.md](KotlinLanguage.md) (`routeOverride: languages/kotlin`)<br>
+[documents/Bananas.md](documents/Bananas.md) (`routeOverride: /fruits/`)
 
 You can use <span id="md-inline-demo">inlined html</span> tags. You can inspect this page to see that "inlined html" is
 wrapped in a span.

--- a/playground/site/src/jsMain/resources/markdown/documents/Bananas.md
+++ b/playground/site/src/jsMain/resources/markdown/documents/Bananas.md
@@ -1,0 +1,12 @@
+---
+root: .components.layouts.PageLayout("BANANAS")
+routeOverride: /fruits/
+---
+
+A banana is an elongated, edible fruit – botanically a berry – produced by several kinds of large herbaceous flowering
+plants in the genus Musa.
+
+In some countries, bananas used for cooking may be called "plantains", distinguishing them from dessert bananas.
+
+The fruit is variable in size, color, and firmness, but is usually elongated and curved, with soft flesh rich in starch
+covered with a rind, which may be green, yellow, red, purple, or brown when ripe.

--- a/playground/site/src/jsMain/resources/markdown/documents/INDEX.md
+++ b/playground/site/src/jsMain/resources/markdown/documents/INDEX.md
@@ -1,0 +1,8 @@
+---
+root: .components.layouts.PageLayout("DOCUMENTS")
+---
+
+Links to some documents:
+
+* [../KotlinLanguage.md](../KotlinLanguage.md)
+* [Bananas.md](Bananas.md)

--- a/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/KotlinRenderer.kt
+++ b/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/KotlinRenderer.kt
@@ -346,7 +346,7 @@ class KotlinRenderer(
         override fun visit(link: Link) {
             // Links to other Markdown files, if the files are present, get converted to their corresponding generated routes
             if (link.destination.endsWith(".md")) {
-                val destinationPath = Path(filePath.substringBeforeLast('/', "")).resolve(link.destination).normalize().toString()
+                val destinationPath = Path(filePath).resolveSibling(link.destination).normalize().toString()
                 val destinationFile = markdownNodeGetter(destinationPath.removePrefix("/"))
                 if (destinationFile != null) {
                     // Retrieve the destination's route override, if present


### PR DESCRIPTION
Implements the feature request in #332, works correctly with route overrides.
Doesn't support linking to files with dynamic route overrides, and will currently simply emit a warning and proceed normally. Please tell if an error and/or stopping execution is more desirable.