### PR TITLE
Preliminary implementation of dispose callback generation for server api

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a question
+    url: https://github.com/varabyte/kobweb/discussions/new?category=q-a
+    about: Ask a question about using Kobweb
+    

--- a/.github/ISSUE_TEMPLATE/process_report.md
+++ b/.github/ISSUE_TEMPLATE/process_report.md
@@ -7,8 +7,7 @@ assignees: ''
 
 ---
 
-*THIS ISSUE TEMPLATE IS ONLY INTENDED FOR USE BY INTERNAL KOBWEB
-DEVELOPERS*
+*THIS ISSUE TEMPLATE IS ONLY INTENDED FOR USE BY INTERNAL KOBWEB DEVELOPERS*
 
-Its purpose is to allow fix / investigate an approach we're using
+Its purpose is to allow us to fix / investigate an approach we're using
 behind the scenes that won't directly be visible to users.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ fun HomePage() {
 **Kobweb is still only publishing pre-release versions, but it's been usable for a while now, and it is getting close to
 stabilization**. Please consider starring the project to indicate interest, so we know we're creating something the
 community wants.
-[How ready is it? ▼](#can-we-kobweb-yet)
+[How ready is it?▼](#can-we-kobweb-yet)
 
 Our goal is to provide:
 
@@ -85,7 +85,7 @@ https://user-images.githubusercontent.com/43705986/135570277-2d67033a-f647-4b04-
 >     Android frontend that can also work with your server. (This video is still useful to watch even if you never intend
 >     to have any other frontend besides web).
 > * It's easy to start with a static layout site and migrate to a full stack site later. (You can read more about
->   [Static vs. Fullstack sites ▼](#static-layout-vs-full-stack-sites) below.)
+>   [Static vs. Fullstack sites▼](#static-layout-vs-full-stack-sites) below.)
 
 # Trying it out yourself
 
@@ -809,7 +809,7 @@ val CustomStyle by ComponentStyle.base {
 ```
 
 Just be aware you may have to break this out again if you find yourself needing to
-support [additional states ▼](#additional-states).
+support [additional states▼](#additional-states).
 
 #### ComponentStyle name
 
@@ -2032,7 +2032,7 @@ fun KobwebPage() {
 ##### Route Override
 
 Kobweb Markdown front matter supports a `routeOverride` key. If present, its value will be passed into the
-generated `@Page` annotation (see the [Route Override section ▲](#route-override) for valid values here).
+generated `@Page` annotation (see the [Route Override section▲](#route-override) for valid values here).
 
 This allows you to give your URL a name that normal Kotlin filename rules don't allow for, such as a hyphen:
 
@@ -2384,7 +2384,7 @@ cd site
 kobweb run
 ```
 
-If you're still having issues, you may want to [connect with us ▼](#connecting-with-us)
+If you're still having issues, you may want to [connect with us▼](#connecting-with-us)
 for support (but understand that getting Kobweb added to complex existing projects may not be something we can currently
 prioritize).
 
@@ -2662,7 +2662,7 @@ You may already have an existing and complex backend, perhaps written with Ktor 
 wondering if you can integrate Kobweb with it.
 
 The recommended solution for now is to export your site using a static layout
-([read more about static layout sites here ▲](#static-layout-vs-full-stack-sites)) and then add code to your backend to
+([read more about static layout sites here▲](#static-layout-vs-full-stack-sites)) and then add code to your backend to
 serve the files yourself, as it is fairly trivial.
 
 When you export a site statically, it will generate all files into your `.kobweb/site` folder. Then, if using Ktor, for
@@ -2819,7 +2819,7 @@ you can use to load fonts from directly.
 > While this is the easiest approach, be sure you won't run into compliance issues! If you use Google Fonts on your
 > site, you may technically be in violation of the GDPR in Europe, because an EU citizen's IP address is communicated to
 > Google and logged. You may wish to find a Europe-safe host instead, or self-host, which you can read about
-> in [the next section ▼](#self-hosted-fonts).
+> in [the next section▼](#self-hosted-fonts).
 
 The font service should give you HTML to add to your site's `<head>` tag. For example, Google Fonts suggests the
 following when I select Roboto Regular 400:
@@ -2982,7 +2982,7 @@ DIY. It would be great to get real world experience to hear what issues users ar
 So, should you use Kobweb at this point? If you are...
 
 * playing around with Compose HTML for the first time and want to get up and running quickly on a toy project:
-    * **YES!!!** Please see the [connecting with us ▼](#connecting-with-us) section
+    * **YES!!!** Please see the [connecting with us▼](#connecting-with-us) section
       below, we'd definitely love to hear from you. It's still a good time if you'd want to have a voice in the
       direction of this project.
 * a Kotlin developer who wants to write a small web app or create a new blog from scratch:
@@ -2990,7 +2990,7 @@ So, should you use Kobweb at this point? If you are...
       with us at our Discord if you try it and have questions or run into missing features.
 * someone who already has an existing project in progress and wants to integrate Kobweb into it:
     * **Maybe not?** Depending on how much work you've done, it may not be a trivial refactor. You can review
-      [this earlier section ▲](#adding-kobweb-to-an-existing-project) if you want to try anyway.
+      [this earlier section▲](#adding-kobweb-to-an-existing-project) if you want to try anyway.
 * a company:
   * **Probably not?** I'm assuming most companies are so risk-averse they would not even use Compose HTML, which Kobweb
     is built on top of. If you *were* considering Compose HTML, however, Kobweb is worth a look.

--- a/README.md
+++ b/README.md
@@ -777,6 +777,27 @@ Box(Modifier.backgroundColor(Colors.Red)) { /* ... */ }
 Box(CustomStyle.toModifier()) { /* ... */ }
 ```
 
+> [!IMPORTANT]
+> When you declare a `ComponentStyle`, it must be public. This is because code gets generated inside a `main.kt` file by
+> the Kobweb Gradle plugin, and that code needs to be able to access your style in order to register it.
+>
+> In general, it's a good idea to think of styles as global anyway, since technically they all live in a globally
+> applied stylesheet, and you have to make sure that the style name is unique across your whole application.
+>
+> You can technically make a style private if you add a bit of boilerplate to handle the registration yourself:
+>
+> ```kotlin
+> @Suppress("PRIVATE_COMPONENT_STYLE")
+> private val SomeCustomStyle by ComponentStyle { /* ... */ }
+>
+> @InitSilk
+> fun registerPrivateStyle(ctx: InitSilkContext) {
+>   ctx.theme.registerComponentStyle(SomeCustomStyle)
+> }
+> ```
+>
+> However, you are encouraged to keep your styles public and let the Kobweb Gradle plugin handle everything for you.
+
 #### `ComponentStyle.base`
 
 You can simplify the syntax of basic component styles a bit further with the `ComponentStyle.base` declaration:
@@ -951,6 +972,27 @@ val HighlightedCustomVariant by CustomStyle.addVariant {
 > A common naming convention for variants is to take their associated style and use its name as a suffix plus the word
 > "Variant", e.g. "ButtonStyle" -> "GhostButtonVariant" and "TextStyle" -> "OutlinedTextVariant".
 
+> [!IMPORTANT]
+> Like a `ComponentStyle`, your `ComponentVariant` must be public. This is for the same reason: because code gets
+> generated inside a `main.kt` file by the Kobweb Gradle plugin, and that code needs to be able to access your variant
+> in order to register it.
+>
+> You can technically make a variant private if you add a bit of boilerplate to handle the registration yourself:
+>
+> ```kotlin
+> @Suppress("PRIVATE_COMPONENT_VARIANT")
+> private val SomeCustomVariant by SomeCustomStyle.addVariant {
+>   /* ... */ 
+> }
+>
+> @InitSilk
+> fun registerPrivateVariant(ctx: InitSilkContext) {
+>   ctx.theme.registerComponentVariant(SomeCustomStyle)
+> }
+> ```
+>
+> However, you are encouraged to keep your variants public and let the Kobweb Gradle plugin handle everything for you.
+
 Variants can be particularly useful if you're defining a custom widget that has default styles, but you want to give
 callers an easy way to deviate from it in special cases.
 
@@ -1077,6 +1119,27 @@ Div(
 The name of the keyframes block is automatically derived from the property name (here, `ShiftRight` is converted into
 `"shift-right"`). You can then use the `toAnimation` method to convert your collection of keyframes into an animation that
 uses them, which you can pass into the `Modifier.animation` modifier.
+
+> [!IMPORTANT]
+> When you declare a `Keyframes` animation, it must be public. This is because code gets generated inside a `main.kt`
+> file by the Kobweb Gradle plugin, and that code needs to be able to access your variant in order to register it.
+>
+> In general, it's a good idea to think of animations as global anyway, since technically they all live in a globally
+> applied stylesheet, and you have to make sure that the animation name is unique across your whole application.
+>
+> You can technically make an animation private if you add a bit of boilerplate to handle the registration yourself:
+>
+> ```kotlin
+> @Suppress("PRIVATE_KEYFRAMES")
+> private val SomeAnim by Keyframes { /* ... */ }
+>
+> @InitSilk
+> fun registerPrivateAnim(ctx: InitSilkContext) {
+>   ctx.stylesheet.registerKeyframes(SomeAnim)
+> }
+> ```
+>
+> However, you are encouraged to keep your animations public and let the Kobweb Gradle plugin handle everything for you.
 
 ### ElementRefScope and raw HTML elements
 

--- a/README.md
+++ b/README.md
@@ -1671,7 +1671,7 @@ kotlin {
 > [!IMPORTANT]
 > `configAsKobwebApplication(includeServer = true)` declares and sets up both `js()` and `jvm()`
 > [Kotlin Multiplatform targets](https://kotlinlang.org/docs/multiplatform-set-up-targets.html) for you. If you don't
-> set `includeServer = true` explicitly, only the JS target will be declared.*
+> set `includeServer = true` explicitly, only the JS target will be declared.
 
 The easy way to check if everything is set up correctly is to open your project inside IntelliJ IDEA, wait for it to
 finish indexing, and check that the `jvmMain` folder is detected as a module (if so, it will be given a special icon

--- a/README.md
+++ b/README.md
@@ -2964,7 +2964,7 @@ At this point:
 * It supports generating pages from Markdown that can reference your Composable code.
 * While it's not quite server-side rendering, you can export static pages which will get hydrated on load.
 * A huge range of CSS properties are supported, along with support for style variables and animations.
-* * You can use the `Modifier` builder for a significant number of css properties.
+* You can use the `Modifier` builder for a significant number of css properties.
 * Silk components are color mode aware and support responsive behavior.
 * There are quite a few widgets available, and it's easy to create your own.
 

--- a/README.md
+++ b/README.md
@@ -3005,6 +3005,7 @@ I'm pleased to mention that Kobweb has received feedback from some satisfied use
 * "Kobweb looks fantastic and I've been [trying] to use kotlin in all parts of [my] hobby stuff and work, so I got real excited when I saw Kobweb, [even though] I hadn't been satisfied with a web framework in a long time. Incredible work."
 * "I started using Kobweb from last week and I have to say this [...] reinvented web development for me. [...] I used to hate html css. After getting hands on kobweb I’m in love with it."
 * "Finally got paid -- all thanks to kobweb 🎉💥"
+* "I didn't wanna learn any JS framework so when I first learned about kobweb it felt like a no-brainer; having built 2 Android apps with compose already and a backend with ktor. One could argue Android developers are the best target audience, since the additional knowledge needed to move an app to web with kobweb is minimal. I love it! 🤩"
 
 # Connecting with us
 

--- a/README.md
+++ b/README.md
@@ -2178,6 +2178,65 @@ $ kobweb create examples/chat
 
 which demonstrates a chat application with its auth and chat functionality each managed in their own separate modules.
 
+## Generating site code at compile time
+
+Occasionally, you might find yourself wanting code for your site that is better generated programmatically than written
+by hand.
+
+The recommended best practice is to create a Gradle task that is associated with its own unique output directory, use
+the task to write some code to disk under that directory, and then add that task as a source directory for your project.
+
+> [!NOTE]
+> The reason to encourage tasks with their own unique output directory is because this approach is very friendly with
+> Gradle caching. You may [read more here](https://docs.gradle.org/current/userguide/build_cache_concepts.html#concepts_overlapping_outputs)
+> to learn about this in more detail.
+>
+> Adding your task as a source directory ensures it will get triggered automatically before the Kobweb tasks responsible
+> for processing your project are themselves run.
+
+You want to do this even if you only plan to generate a single file. This is because associating your task with an
+output directory is what enables it to be used in place of a source directory.
+
+The structure for this approach generally looks like this:
+
+```kotlin
+// e.g. site/build.gradle.kts
+
+val generateCodeTask = tasks.register("generateCode") {
+  group = "myproject"
+  // You may not need an input file or dir for your task, and if so, you can exclude the next line. If you do need one,
+  // I'm assuming it is a data file or files in your resources somewhere.
+  val resInputDir = layout.projectDirectory.dir("src/jsMain/resources")
+  val genOutputDir = layout.buildDirectory.dir("generated/$group/src/jsMain/kotlin")
+
+  inputs.dir(resInputDir).withPathSensitivity(PathSensitivity.RELATIVE)
+  outputs.dir(genOutputDir)
+
+  doLast {
+    genOutputDir.get().file("org/example/pages/SomeCode.kt").asFile.apply {
+      parentFile.mkdirs()
+      // find and parse file out of resInputDir and write generated code here:
+      writeText(/* ... */)
+
+      println("Generated $absolutePath")
+    }
+  }
+}
+
+kotlin {
+  configAsKobwebApplication()
+  val commonMain by getting { /* ... */ }
+  val jsMain by getting {
+    kotlin.srcDir(generateCodeTask) // <----- Set your task here
+    dependencies { /* ... */ }
+  }
+}
+```
+
+If you want to see this working in action, you
+can [check out my blog site's build script here](https://github.com/bitspittle/bitspittle.dev/blob/f7208543046e25337e73b5ede07ff576623962b0/site/build.gradle.kts#L104),
+where it is used to generate a listing page for all blog posts.
+
 ## Adding Kobweb to an existing project
 
 Currently, Kobweb is still under active development, and due to our limited resources, we are focusing on improving the

--- a/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/ApisFactory.kt
+++ b/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/ApisFactory.kt
@@ -11,4 +11,5 @@ import com.varabyte.kobweb.api.log.Logger
 @Suppress("unused") // Called by reflection
 interface ApisFactory {
     fun create(logger: Logger): Apis
+    fun dispose()
 }

--- a/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/dispose/DisposeApi.kt
+++ b/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/dispose/DisposeApi.kt
@@ -1,0 +1,7 @@
+package com.varabyte.kobweb.api.dispose
+
+/**
+ * An annotation which identifies a function as one which will be called when the server reloads the api in dev mode.
+ */
+@Target(AnnotationTarget.FUNCTION)
+annotation class DisposeApi

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/templates/ApiFactoryTemplate.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/templates/ApiFactoryTemplate.kt
@@ -24,6 +24,10 @@ fun createApisFactoryImpl(backendData: BackendData): String {
     //        example.init(initCtx)
     //        return apis
     //    }
+    //
+    //    override fun dispose() {
+    //        example.dispose()
+    //    }
     //  }
 
     val fileBuilder = FileSpec.builder("", "ApisFactoryImpl").indent(" ".repeat(4))
@@ -60,6 +64,18 @@ fun createApisFactoryImpl(backendData: BackendData): String {
                         }
                         addStatement("")
                         addStatement("return apis")
+                    }.build())
+                    .build()
+            )
+            .addFunction(
+                FunSpec.builder("dispose")
+                    .addModifiers(KModifier.OVERRIDE)
+                    .addCode(CodeBlock.builder().apply {
+                        if (backendData.disposeMethods.isNotEmpty()) {
+                            backendData.disposeMethods.sortedBy { entry -> entry.fqn }.forEach { entry ->
+                                addStatement("${entry.fqn}()")
+                            }
+                        }
                     }.build())
                     .build()
             )

--- a/tools/ksp/project-processors/src/main/kotlin/com/varabyte/kobweb/ksp/common/NameConstants.kt
+++ b/tools/ksp/project-processors/src/main/kotlin/com/varabyte/kobweb/ksp/common/NameConstants.kt
@@ -6,6 +6,7 @@ private const val KOBWEB_SILK_FQN_PREFIX = "${KOBWEB_FQN_PREFIX}silk."
 private const val KOBWEB_API_FQN_PREFIX = "${KOBWEB_FQN_PREFIX}api."
 
 const val INIT_API_FQN = "${KOBWEB_API_FQN_PREFIX}init.InitApi"
+const val DISPOSE_API_FQN = "${KOBWEB_API_FQN_PREFIX}dispose.DisposeApi"
 const val PACKAGE_MAPPING_API_FQN = "${KOBWEB_API_FQN_PREFIX}PackageMapping"
 const val API_FQN = "${KOBWEB_API_FQN_PREFIX}Api"
 const val API_STREAM_SIMPLE_NAME = "ApiStream"

--- a/tools/processor-common/src/main/kotlin/com/varabyte/kobweb/project/backend/BackendData.kt
+++ b/tools/processor-common/src/main/kotlin/com/varabyte/kobweb/project/backend/BackendData.kt
@@ -8,12 +8,14 @@ import kotlinx.serialization.Serializable
  * @param initMethods A collection of methods annotated with `@InitApi` and relevant metadata.
  * @param apiMethods A collection of methods annotated with `@Api` and relevant metadata.
  * @param apiStreamMethods A collection of ApiStream properties and relevant metadata.
+ * @param disposeMethods A collection of methods annotated with `@DisposeApi` and relevant metadata.
  */
 @Serializable
 class BackendData(
     val initMethods: List<InitApiEntry>,
     val apiMethods: List<ApiEntry>,
-    val apiStreamMethods: List<ApiStreamEntry>
+    val apiStreamMethods: List<ApiStreamEntry>,
+    val disposeMethods: List<DisposeApiEntry>
 )
 
 /**
@@ -26,6 +28,7 @@ fun Iterable<BackendData>.merge(throwError: (String) -> Unit): BackendData {
         this.flatMap { it.initMethods },
         this.flatMap { it.apiMethods },
         this.flatMap { it.apiStreamMethods },
+        this.flatMap { it.disposeMethods },
     ).also { it.assertValid(throwError) }
 }
 
@@ -50,3 +53,6 @@ class ApiStreamEntry(val fqn: String, val route: String)
 
 @Serializable
 class ApiEntry(val fqn: String, val route: String)
+
+@Serializable
+class DisposeApiEntry(val fqn: String)


### PR DESCRIPTION
This pull request accompanies this discussion #350 

It adds a @DisposeApi annotation next to the @InitApi annotation and adds the encessary code generation to add a dispose function to the ApiJarFile. 

This dispose function is currently called when the cache of the ApiJarFileImpl gets invalidated. This currently is only relevant for the DEV mode.

As the ApiJarFileImpl is quite deeply hidden and I already exposed it from the cache, I did not implement that the dispose function is also called when the actual server shutdown, but it should for consistency be also called on shutdown. Hence this part would still be a TODO.