### PR TITLE
Dispose api callback, cleanup api after dev server reload

### DIFF
--- a/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/ApisFactory.kt
+++ b/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/ApisFactory.kt
@@ -10,4 +10,5 @@ import com.varabyte.kobweb.api.log.Logger
  */
 interface ApisFactory {
     fun create(logger: Logger): Apis
+    fun dispose()
 }

--- a/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/dispose/DisposeApi.kt
+++ b/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/dispose/DisposeApi.kt
@@ -1,0 +1,7 @@
+package com.varabyte.kobweb.api.dispose
+
+/**
+ * An annotation which identifies a function as one which will be called when the server reloads the api in dev mode.
+ */
+@Target(AnnotationTarget.FUNCTION)
+annotation class DisposeApi

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/templates/ApiFactoryTemplate.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/templates/ApiFactoryTemplate.kt
@@ -24,6 +24,10 @@ fun createApisFactoryImpl(backendData: BackendData): String {
     //        example.init(initCtx)
     //        return apis
     //    }
+    //
+    //    override fun dispose() {
+    //        example.dispose()
+    //    }
     //  }
 
     val fileBuilder = FileSpec.builder("", "ApisFactoryImpl").indent(" ".repeat(4))
@@ -60,6 +64,18 @@ fun createApisFactoryImpl(backendData: BackendData): String {
                         }
                         addStatement("")
                         addStatement("return apis")
+                    }.build())
+                    .build()
+            )
+            .addFunction(
+                FunSpec.builder("dispose")
+                    .addModifiers(KModifier.OVERRIDE)
+                    .addCode(CodeBlock.builder().apply {
+                        if (backendData.disposeMethods.isNotEmpty()) {
+                            backendData.disposeMethods.sortedBy { entry -> entry.fqn }.forEach { entry ->
+                                addStatement("${entry.fqn}()")
+                            }
+                        }
                     }.build())
                     .build()
             )

--- a/tools/ksp/project-processors/src/main/kotlin/com/varabyte/kobweb/ksp/common/NameConstants.kt
+++ b/tools/ksp/project-processors/src/main/kotlin/com/varabyte/kobweb/ksp/common/NameConstants.kt
@@ -6,6 +6,7 @@ private const val KOBWEB_SILK_FQN_PREFIX = "${KOBWEB_FQN_PREFIX}silk."
 private const val KOBWEB_API_FQN_PREFIX = "${KOBWEB_FQN_PREFIX}api."
 
 const val INIT_API_FQN = "${KOBWEB_API_FQN_PREFIX}init.InitApi"
+const val DISPOSE_API_FQN = "${KOBWEB_API_FQN_PREFIX}dispose.DisposeApi"
 const val PACKAGE_MAPPING_API_FQN = "${KOBWEB_API_FQN_PREFIX}PackageMapping"
 const val API_FQN = "${KOBWEB_API_FQN_PREFIX}Api"
 const val API_STREAM_SIMPLE_NAME = "ApiStream"

--- a/tools/processor-common/src/main/kotlin/com/varabyte/kobweb/project/backend/BackendData.kt
+++ b/tools/processor-common/src/main/kotlin/com/varabyte/kobweb/project/backend/BackendData.kt
@@ -8,12 +8,14 @@ import kotlinx.serialization.Serializable
  * @param initMethods A collection of methods annotated with `@InitApi` and relevant metadata.
  * @param apiMethods A collection of methods annotated with `@Api` and relevant metadata.
  * @param apiStreamMethods A collection of ApiStream properties and relevant metadata.
+ * @param disposeMethods A collection of methods annotated with `@DisposeApi` and relevant metadata.
  */
 @Serializable
 class BackendData(
     val initMethods: List<InitApiEntry>,
     val apiMethods: List<ApiEntry>,
-    val apiStreamMethods: List<ApiStreamEntry>
+    val apiStreamMethods: List<ApiStreamEntry>,
+    val disposeMethods: List<DisposeApiEntry>
 )
 
 /**
@@ -26,6 +28,7 @@ fun Iterable<BackendData>.merge(throwError: (String) -> Unit): BackendData {
         this.flatMap { it.initMethods },
         this.flatMap { it.apiMethods },
         this.flatMap { it.apiStreamMethods },
+        this.flatMap { it.disposeMethods },
     ).also { it.assertValid(throwError) }
 }
 
@@ -50,3 +53,6 @@ class ApiStreamEntry(val fqn: String, val route: String)
 
 @Serializable
 class ApiEntry(val fqn: String, val route: String)
+
+@Serializable
+class DisposeApiEntry(val fqn: String)


### PR DESCRIPTION
This pull request accompanies this discussion https://github.com/varabyte/kobweb/discussions/350

It adds a @DisposeApi annotation next to the @InitApi annotation and adds the encessary code generation to add a dispose function to the ApiJarFile.

This dispose function is currently called when the cache of the ApiJarFileImpl gets invalidated. This currently is only relevant for the DEV mode.

As the ApiJarFileImpl is quite deeply hidden and I already exposed it from the cache, I did not implement that the dispose function is also called when the actual server shutdown, but it should for consistency be also called on shutdown. Hence this part would still be a TODO.