### PR TITLE
Provide a `ProjectLayout` instance in the base kobweb task

### DIFF
--- a/tools/gradle-plugins/core/src/main/kotlin/com/varabyte/kobweb/gradle/core/tasks/KobwebGenerateModuleMetadataTask.kt
+++ b/tools/gradle-plugins/core/src/main/kotlin/com/varabyte/kobweb/gradle/core/tasks/KobwebGenerateModuleMetadataTask.kt
@@ -5,19 +5,14 @@ import com.varabyte.kobweb.gradle.core.util.KobwebVersionUtil
 import com.varabyte.kobweb.ksp.KOBWEB_METADATA_MODULE
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import org.gradle.api.file.ProjectLayout
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
-import javax.inject.Inject
 
 abstract class KobwebGenerateModuleMetadataTask :
     KobwebTask("Generate a module.json metadata file into this project's jar metadata, which identifies this artifact as one built by Kobweb.") {
     @Input
     fun getKobwebVersion() = KobwebVersionUtil.version
-
-    @get:Inject
-    abstract val projectLayout: ProjectLayout
 
     @OutputDirectory
     fun getGenResDir() = projectLayout.buildDirectory.dir("generated/kobweb/module")

--- a/tools/gradle-plugins/core/src/main/kotlin/com/varabyte/kobweb/gradle/core/tasks/KobwebTask.kt
+++ b/tools/gradle-plugins/core/src/main/kotlin/com/varabyte/kobweb/gradle/core/tasks/KobwebTask.kt
@@ -2,6 +2,7 @@ package com.varabyte.kobweb.gradle.core.tasks
 
 import com.varabyte.kobweb.project.KobwebApplication
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.tasks.Internal
 import javax.inject.Inject
 
@@ -9,6 +10,9 @@ import javax.inject.Inject
  * Minimal base class for ensuring that the current task is grouped consistently with other Kobweb tasks.
  */
 abstract class KobwebTask @Inject constructor(desc: String) : DefaultTask() {
+    @get:Inject
+    abstract val projectLayout: ProjectLayout
+
     /**
      * Request access to a [KobwebApplication] instance.
      *
@@ -18,7 +22,7 @@ abstract class KobwebTask @Inject constructor(desc: String) : DefaultTask() {
      * See also: [KobwebApplication] for more details.
      */
     @get:Internal
-    val kobwebApplication get() = KobwebApplication(project.layout.projectDirectory.asFile.toPath())
+    val kobwebApplication get() = KobwebApplication(projectLayout.projectDirectory.asFile.toPath())
 
     init {
         group = "kobweb"

--- a/tools/gradle-plugins/library/src/main/kotlin/com/varabyte/kobweb/gradle/library/tasks/KobwebGenerateIndexMetadataTask.kt
+++ b/tools/gradle-plugins/library/src/main/kotlin/com/varabyte/kobweb/gradle/library/tasks/KobwebGenerateIndexMetadataTask.kt
@@ -13,7 +13,6 @@ import kotlinx.html.stream.createHTML
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.gradle.api.Project
-import org.gradle.api.file.ProjectLayout
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import javax.inject.Inject
@@ -24,9 +23,6 @@ import javax.inject.Inject
 @Deprecated("Migrated to KobwebGenerateLibraryMetadataTask")
 abstract class KobwebGenerateIndexMetadataTask @Inject constructor(private val project: Project) :
     KobwebTask("Generate an index.json metadata file into this project's jar metadata, which contains details from the kobweb index block.") {
-
-    @get:Inject
-    abstract val projectLayout: ProjectLayout
 
     @OutputDirectory
     fun getGenResDir() = projectLayout.buildDirectory.dir("generated/kobweb/library/index/metadata")

--- a/tools/gradle-plugins/library/src/main/kotlin/com/varabyte/kobweb/gradle/library/tasks/KobwebGenerateLibraryMetadataTask.kt
+++ b/tools/gradle-plugins/library/src/main/kotlin/com/varabyte/kobweb/gradle/library/tasks/KobwebGenerateLibraryMetadataTask.kt
@@ -11,16 +11,12 @@ import kotlinx.html.stream.createHTML
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.gradle.api.Project
-import org.gradle.api.file.ProjectLayout
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import javax.inject.Inject
 
 abstract class KobwebGenerateLibraryMetadataTask @Inject constructor(private val project: Project) :
     KobwebTask("Generate a library.json metadata file into this project's jar metadata, which identifies this artifact as a Kobweb library.") {
-
-    @get:Inject
-    abstract val projectLayout: ProjectLayout
 
     @OutputDirectory
     fun getGenResDir() = projectLayout.buildDirectory.dir("generated/kobweb/library/metadata")

--- a/tools/gradle-plugins/worker/src/main/kotlin/com/varabyte/kobweb/gradle/worker/tasks/KobwebGenerateWorkerMetadataTask.kt
+++ b/tools/gradle-plugins/worker/src/main/kotlin/com/varabyte/kobweb/gradle/worker/tasks/KobwebGenerateWorkerMetadataTask.kt
@@ -5,16 +5,11 @@ import com.varabyte.kobweb.gradle.core.tasks.KobwebTask
 import com.varabyte.kobweb.ksp.KOBWEB_METADATA_WORKER
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import org.gradle.api.file.ProjectLayout
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
-import javax.inject.Inject
 
 abstract class KobwebGenerateWorkerMetadataTask :
     KobwebTask("Generate a worker.json metadata file into this project's jar metadata, which identifies this artifact as a Kobweb worker.") {
-
-    @get:Inject
-    abstract val projectLayout: ProjectLayout
 
     @OutputDirectory
     fun getGenResDir() = projectLayout.buildDirectory.dir("generated/kobweb/worker/metadata")


### PR DESCRIPTION
This makes the base task compatible with configuration cache and eliminates a bunch of repeated declarations.