### PR TITLE
Make `kobwebGenerateLibraryMetadata` compatible with configuration cache

### DIFF
--- a/tools/gradle-plugins/library/src/main/kotlin/com/varabyte/kobweb/gradle/library/KobwebLibraryPlugin.kt
+++ b/tools/gradle-plugins/library/src/main/kotlin/com/varabyte/kobweb/gradle/library/KobwebLibraryPlugin.kt
@@ -16,11 +16,15 @@ import com.varabyte.kobweb.gradle.core.ksp.setupKspJs
 import com.varabyte.kobweb.gradle.core.ksp.setupKspJvm
 import com.varabyte.kobweb.gradle.core.util.generateModuleMetadataFor
 import com.varabyte.kobweb.gradle.library.extensions.createLibraryBlock
+import com.varabyte.kobweb.gradle.library.extensions.index
+import com.varabyte.kobweb.gradle.library.extensions.library
 import com.varabyte.kobweb.gradle.library.tasks.KobwebGenerateIndexMetadataTask
 import com.varabyte.kobweb.gradle.library.tasks.KobwebGenerateLibraryMetadataTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.kotlin.dsl.assign
+import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrTarget
 import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
@@ -33,9 +37,11 @@ class KobwebLibraryPlugin : Plugin<Project> {
         project.applyKspPlugin()
 
         val kobwebGenerateIndexMetadataTask =
-            project.tasks.register("kobwebGenerateIndexMetadataTask", KobwebGenerateIndexMetadataTask::class.java)
-        val kobwebGenerateLibraryMetadataTask =
-            project.tasks.register("kobwebGenerateLibraryMetadataTask", KobwebGenerateLibraryMetadataTask::class.java)
+            project.tasks.register<KobwebGenerateIndexMetadataTask>("kobwebGenerateIndexMetadata")
+        val kobwebGenerateLibraryMetadataTask = project.tasks
+            .register<KobwebGenerateLibraryMetadataTask>("kobwebGenerateLibraryMetadata") {
+                indexHead = project.kobwebBlock.library.index.head
+            }
         project.buildTargets.withType<KotlinJsIrTarget>().configureEach {
             val jsTarget = JsTarget(this)
             project.setupKspJs(jsTarget, ProcessorMode.LIBRARY)

--- a/tools/gradle-plugins/library/src/main/kotlin/com/varabyte/kobweb/gradle/library/tasks/KobwebGenerateLibraryMetadataTask.kt
+++ b/tools/gradle-plugins/library/src/main/kotlin/com/varabyte/kobweb/gradle/library/tasks/KobwebGenerateLibraryMetadataTask.kt
@@ -1,22 +1,23 @@
 package com.varabyte.kobweb.gradle.library.tasks
 
-import com.varabyte.kobweb.gradle.core.extensions.kobwebBlock
 import com.varabyte.kobweb.gradle.core.metadata.LibraryMetadata
 import com.varabyte.kobweb.gradle.core.tasks.KobwebTask
-import com.varabyte.kobweb.gradle.library.extensions.index
-import com.varabyte.kobweb.gradle.library.extensions.library
 import com.varabyte.kobweb.ksp.KOBWEB_METADATA_LIBRARY
+import kotlinx.html.HEAD
 import kotlinx.html.head
 import kotlinx.html.stream.createHTML
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import org.gradle.api.Project
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
-import javax.inject.Inject
 
-abstract class KobwebGenerateLibraryMetadataTask @Inject constructor(private val project: Project) :
+abstract class KobwebGenerateLibraryMetadataTask :
     KobwebTask("Generate a library.json metadata file into this project's jar metadata, which identifies this artifact as a Kobweb library.") {
+
+    @get:Input
+    abstract val indexHead: ListProperty<HEAD.() -> Unit>
 
     @OutputDirectory
     fun getGenResDir() = projectLayout.buildDirectory.dir("generated/kobweb/library/metadata")
@@ -27,8 +28,7 @@ abstract class KobwebGenerateLibraryMetadataTask @Inject constructor(private val
         libraryMetadataFile.asFile.apply {
             parentFile.mkdirs()
 
-            val libraryBlock = project.kobwebBlock.library
-            val headElements = libraryBlock.index.head.orNull?.takeIf { it.isNotEmpty() }
+            val headElements = indexHead.orNull?.takeIf { it.isNotEmpty() }
             writeText(
                 Json.encodeToString(
                     LibraryMetadata(


### PR DESCRIPTION
Also remove the "Task" suffix from the task name for consistency with other tasks.