### PR TITLE
Move ksp processor mode setup out of JS setup

### DIFF
--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/KobwebApplicationPlugin.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/KobwebApplicationPlugin.kt
@@ -29,6 +29,7 @@ import com.varabyte.kobweb.gradle.core.kmp.jsTarget
 import com.varabyte.kobweb.gradle.core.kmp.jvmTarget
 import com.varabyte.kobweb.gradle.core.kmp.kotlin
 import com.varabyte.kobweb.gradle.core.ksp.applyKspPlugin
+import com.varabyte.kobweb.gradle.core.ksp.setKspMode
 import com.varabyte.kobweb.gradle.core.ksp.setupKspJs
 import com.varabyte.kobweb.gradle.core.ksp.setupKspJvm
 import com.varabyte.kobweb.gradle.core.tasks.KobwebTask
@@ -80,6 +81,8 @@ class KobwebApplicationPlugin @Inject constructor(
     override fun apply(project: Project) {
         project.pluginManager.apply(KobwebCorePlugin::class.java)
         project.applyKspPlugin()
+        val kspProcessorMode = ProcessorMode.APP
+        project.setKspMode(kspProcessorMode)
 
         // A Kobweb Server Plugin is one which is loaded by the Kobweb server when it starts up. It's a way for users to
         // configure their ktor server in ways that Kobweb does not currently expose.
@@ -243,7 +246,7 @@ class KobwebApplicationPlugin @Inject constructor(
         project.buildTargets.withType<KotlinJsIrTarget>().configureEach {
             val jsTarget = JsTarget(this)
 
-            project.setupKspJs(jsTarget, ProcessorMode.APP)
+            project.setupKspJs(jsTarget, kspProcessorMode)
 
             val kobwebGenSiteEntryTask = project.tasks
                 .register<KobwebGenerateSiteEntryTask>("kobwebGenSiteEntry", kobwebConf, kobwebBlock, buildTarget)

--- a/tools/gradle-plugins/core/src/main/kotlin/com/varabyte/kobweb/gradle/core/ksp/KspSetup.kt
+++ b/tools/gradle-plugins/core/src/main/kotlin/com/varabyte/kobweb/gradle/core/ksp/KspSetup.kt
@@ -22,6 +22,8 @@ import org.gradle.language.jvm.tasks.ProcessResources
 
 fun Project.applyKspPlugin() = pluginManager.apply(KspGradleSubplugin::class.java)
 
+fun Project.setKspMode(mode: ProcessorMode) = addKspArguments(KSP_PROCESSOR_MODE_KEY to mode.name)
+
 // TODO: we currently set KSP_*_PACKAGE_KEY using task.project.group since the project.group of where the plugin is
 //  applied may be different. However, task.project is not recommended to be used, what are our alternatives?
 
@@ -34,8 +36,7 @@ fun Project.setupKspJs(target: JsTarget, mode: ProcessorMode) {
             KSP_PAGES_PACKAGE_KEY to PackageUtils.resolvePackageShortcut(
                 this@configureEach.project.group.toString(),
                 kobwebBlock.pagesPackage.get()
-            ),
-            KSP_PROCESSOR_MODE_KEY to mode.toString()
+            )
         )
     }
 

--- a/tools/gradle-plugins/library/src/main/kotlin/com/varabyte/kobweb/gradle/library/KobwebLibraryPlugin.kt
+++ b/tools/gradle-plugins/library/src/main/kotlin/com/varabyte/kobweb/gradle/library/KobwebLibraryPlugin.kt
@@ -12,6 +12,7 @@ import com.varabyte.kobweb.gradle.core.kmp.jsTarget
 import com.varabyte.kobweb.gradle.core.kmp.jvmTarget
 import com.varabyte.kobweb.gradle.core.kmp.kotlin
 import com.varabyte.kobweb.gradle.core.ksp.applyKspPlugin
+import com.varabyte.kobweb.gradle.core.ksp.setKspMode
 import com.varabyte.kobweb.gradle.core.ksp.setupKspJs
 import com.varabyte.kobweb.gradle.core.ksp.setupKspJvm
 import com.varabyte.kobweb.gradle.core.util.generateModuleMetadataFor
@@ -35,6 +36,8 @@ class KobwebLibraryPlugin : Plugin<Project> {
         project.pluginManager.apply(KobwebCorePlugin::class.java)
         project.kobwebBlock.createLibraryBlock()
         project.applyKspPlugin()
+        val kspProcessorMode = ProcessorMode.LIBRARY
+        project.setKspMode(kspProcessorMode)
 
         val kobwebGenerateIndexMetadataTask =
             project.tasks.register<KobwebGenerateIndexMetadataTask>("kobwebGenerateIndexMetadata")
@@ -44,7 +47,7 @@ class KobwebLibraryPlugin : Plugin<Project> {
             }
         project.buildTargets.withType<KotlinJsIrTarget>().configureEach {
             val jsTarget = JsTarget(this)
-            project.setupKspJs(jsTarget, ProcessorMode.LIBRARY)
+            project.setupKspJs(jsTarget, kspProcessorMode)
             project.generateModuleMetadataFor(jsTarget)
             project.kotlin.sourceSets.named(jsTarget.mainSourceSet) {
                 resources.srcDir(kobwebGenerateLibraryMetadataTask)


### PR DESCRIPTION
This allows running jvm-related ksp tasks individually.