### PR TITLE
Remove unnecessary functions in `KobwebModuleTask`

### DIFF
--- a/tools/gradle-plugins/core/src/main/kotlin/com/varabyte/kobweb/gradle/core/tasks/KobwebModuleTask.kt
+++ b/tools/gradle-plugins/core/src/main/kotlin/com/varabyte/kobweb/gradle/core/tasks/KobwebModuleTask.kt
@@ -3,29 +3,17 @@ package com.varabyte.kobweb.gradle.core.tasks
 import com.varabyte.kobweb.gradle.core.extensions.KobwebBlock
 import com.varabyte.kobweb.gradle.core.kmp.jsTarget
 import com.varabyte.kobweb.gradle.core.util.RootAndFile
-import com.varabyte.kobweb.gradle.core.util.getBuildScripts
 import com.varabyte.kobweb.gradle.core.util.getResourceFilesWithRoots
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
-import java.io.File
 
 /**
  * Base class for any task that needs to know about any source / resources related to Kobweb in the current module.
  */
 abstract class KobwebModuleTask(@get:Internal val kobwebBlock: KobwebBlock, desc: String) : KobwebTask(desc) {
-    @InputFiles
-    @PathSensitive(PathSensitivity.RELATIVE) // rerun if contents or path relative to project root changes
-    fun getBuildScripts(): List<File> = project.getBuildScripts().toList()
-
     @Internal
     fun getResourceFilesJsWithRoots(): Sequence<RootAndFile> = project.getResourceFilesWithRoots(project.jsTarget)
         .filter { rootAndFile -> rootAndFile.relativeFile.invariantSeparatorsPath.startsWith("${getPublicPath()}/") }
-
-    @Internal
-    protected fun getResourceFilesJs(): List<File> = getResourceFilesJsWithRoots().map { it.file }.toList()
 
     /**
      * The root package of all pages.

--- a/tools/gradle-plugins/core/src/main/kotlin/com/varabyte/kobweb/gradle/core/util/ProjectExtensions.kt
+++ b/tools/gradle-plugins/core/src/main/kotlin/com/varabyte/kobweb/gradle/core/util/ProjectExtensions.kt
@@ -12,7 +12,6 @@ import org.gradle.language.jvm.tasks.ProcessResources
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import java.io.File
 import java.security.MessageDigest
-import kotlin.math.absoluteValue
 
 private fun Project.getRoots(
     platform: TargetPlatform<*>,
@@ -44,12 +43,6 @@ private fun Project.getFilesWithRoots(
 
 fun Project.getResourceFilesWithRoots(platform: TargetPlatform<*>): Sequence<RootAndFile> {
     return project.getFilesWithRoots(platform) { sourceSet -> sourceSet.resources }
-}
-
-fun Project.getBuildScripts(): Sequence<File> {
-    return sequenceOf("build.gradle", "build.gradle.kts")
-        .map { script -> project.layout.projectDirectory.file(script).asFile }
-        .filter { it.exists() }
 }
 
 /**


### PR DESCRIPTION
We do not need to depend on the buildscripts directly, as each task declares the inputs it needs, and gradle will rerun the task if they change.