### PR TITLE
Support multi-round processing in KSP processors

### DIFF
--- a/tools/ksp/site-processors/src/main/kotlin/com/varabyte/kobweb/ksp/backend/BackendProcessor.kt
+++ b/tools/ksp/site-processors/src/main/kotlin/com/varabyte/kobweb/ksp/backend/BackendProcessor.kt
@@ -37,12 +37,15 @@ class BackendProcessor(
     private val genFile: String,
     private val qualifiedApiPackage: String,
 ) : SymbolProcessor {
-    private lateinit var initMethods: List<InitApiEntry>
-    private lateinit var apiMethods: List<ApiEntry>
-    private val apiStreams = mutableListOf<ApiStreamEntry>()
+    private val apiVisitor = ApiVisitor()
+
+    private val initMethods = mutableListOf<InitApiEntry>()
+
+    private val apiMethodsDeclarations = mutableListOf<KSFunctionDeclaration>()
+    private val apiStreamsDeclarations = mutableListOf<KSPropertyDeclaration>()
 
     // fqPkg to subdir, e.g. "api.id._as._int" to "int"
-    private lateinit var packageMappings: Map<String, String>
+    private val packageMappings = mutableMapOf<String, String>()
 
     // We track all files we depend on so that ksp can perform smart recompilation
     // Even though our output is aggregating so generally requires full reprocessing, this at minimum means processing
@@ -50,30 +53,25 @@ class BackendProcessor(
     private val fileDependencies = mutableListOf<KSFile>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
-        initMethods = resolver.getSymbolsWithAnnotation(INIT_API_FQN).map { annotatedFun ->
+        initMethods += resolver.getSymbolsWithAnnotation(INIT_API_FQN).map { annotatedFun ->
             fileDependencies.add(annotatedFun.containingFile!!)
             val name = (annotatedFun as KSFunctionDeclaration).qualifiedName!!.asString()
             InitApiEntry(name)
-        }.toList()
+        }
 
-        val allFiles = resolver.getAllFiles()
+        val newFiles = resolver.getNewFiles()
 
         // package mapping must be processed before api methods & streams
-        packageMappings = allFiles.flatMap { file ->
+        packageMappings += newFiles.flatMap { file ->
             getPackageMappings(file, qualifiedApiPackage, PACKAGE_MAPPING_API_FQN, logger).toList()
                 .also { if (it.isNotEmpty()) fileDependencies.add(file) }
-        }.toMap()
+        }
 
-        apiMethods = resolver.getSymbolsWithAnnotation(API_FQN)
+        apiMethodsDeclarations += resolver.getSymbolsWithAnnotation(API_FQN)
             .filterIsInstance<KSFunctionDeclaration>() // @Api for stream properties is handled separately
-            .mapNotNull { annotatedFun ->
-                processApiFun(annotatedFun, qualifiedApiPackage, packageMappings, logger)
-                    ?.also { fileDependencies.add(annotatedFun.containingFile!!) }
-            }.toList()
 
-        val visitor = ApiVisitor()
-        allFiles.forEach { file ->
-            file.accept(visitor, Unit)
+        newFiles.forEach { file ->
+            file.accept(apiVisitor, Unit)
         }
 
         return emptyList()
@@ -109,20 +107,7 @@ class BackendProcessor(
                 return
             }
             fileDependencies.add(property.containingFile!!)
-
-            val routeOverride = property.getAnnotationsByName(API_FQN)
-                .firstNotNullOfOrNull { it.arguments.firstOrNull()?.value?.toString() }
-
-            val resolvedRoute = processRoute(
-                pkg = property.packageName.asString(),
-                slugFromFile = property.containingFile!!.nameWithoutExtension.lowercase(),
-                routeOverride = routeOverride,
-                qualifiedPackage = qualifiedApiPackage,
-                packageMappings = packageMappings,
-                supportDynamicRoute = false,
-            )
-
-            apiStreams.add(ApiStreamEntry(property.qualifiedName!!.asString(), resolvedRoute))
+            apiStreamsDeclarations += property
         }
 
         override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: Unit) {
@@ -135,6 +120,28 @@ class BackendProcessor(
     }
 
     override fun finish() {
+        // api declarations must be processed at the end, as they rely on package mappings,
+        // which may be populated over several rounds
+        val apiMethods = apiMethodsDeclarations.mapNotNull { annotatedFun ->
+            processApiFun(annotatedFun, qualifiedApiPackage, packageMappings, logger)
+                ?.also { fileDependencies.add(annotatedFun.containingFile!!) }
+        }
+        val apiStreams = apiStreamsDeclarations.map { property ->
+            val routeOverride = property.getAnnotationsByName(API_FQN)
+                .firstNotNullOfOrNull { it.arguments.firstOrNull()?.value?.toString() }
+
+            val resolvedRoute = processRoute(
+                pkg = property.packageName.asString(),
+                slugFromFile = property.containingFile!!.nameWithoutExtension.lowercase(),
+                routeOverride = routeOverride,
+                qualifiedPackage = qualifiedApiPackage,
+                packageMappings = packageMappings,
+                supportDynamicRoute = false,
+            )
+
+            ApiStreamEntry(property.qualifiedName!!.asString(), resolvedRoute)
+        }
+
         val backendData = BackendData(initMethods, apiMethods, apiStreams).also {
             it.assertValid(throwError = { msg -> logger.error(msg) })
         }


### PR DESCRIPTION
While the kobweb processors do not themselves need to be run across several rounds, external KSP processors may generate code that the kobweb processors should process in subsequent rounds. This change ensures that state is saved in between rounds, and any processing that relies on the complete results is done in the processors `finish()` function.

Fixes #442