### PR TITLE
Fix KSP using incomplete file dependencies

### DIFF
--- a/tools/ksp/site-processors/src/main/kotlin/com/varabyte/kobweb/ksp/frontend/AppProcessor.kt
+++ b/tools/ksp/site-processors/src/main/kotlin/com/varabyte/kobweb/ksp/frontend/AppProcessor.kt
@@ -50,9 +50,9 @@ class AppProcessor(
     }
 
     override fun finish() {
-        val (frontendData, files) = frontendProcessor.getFinalizedData()
-        fileDependencies.addAll(files)
-        val appData = AppData(appFqn?.let { AppEntry(it) }, frontendData)
+        val frontendResult = frontendProcessor.getProcessorResult()
+        fileDependencies.addAll(frontendResult.fileDependencies)
+        val appData = AppData(appFqn?.let { AppEntry(it) }, frontendResult.data)
 
         val (path, extension) = genFile.split('.')
         codeGenerator.createNewFileByPath(

--- a/tools/ksp/site-processors/src/main/kotlin/com/varabyte/kobweb/ksp/frontend/AppProcessor.kt
+++ b/tools/ksp/site-processors/src/main/kotlin/com/varabyte/kobweb/ksp/frontend/AppProcessor.kt
@@ -50,8 +50,9 @@ class AppProcessor(
     }
 
     override fun finish() {
-        fileDependencies.addAll(frontendProcessor.fileDependencies)
-        val appData = AppData(appFqn?.let { AppEntry(it) }, frontendProcessor.getData())
+        val (frontendData, files) = frontendProcessor.getFinalizedData()
+        fileDependencies.addAll(files)
+        val appData = AppData(appFqn?.let { AppEntry(it) }, frontendData)
 
         val (path, extension) = genFile.split('.')
         codeGenerator.createNewFileByPath(

--- a/tools/ksp/site-processors/src/main/kotlin/com/varabyte/kobweb/ksp/frontend/FrontendProcessor.kt
+++ b/tools/ksp/site-processors/src/main/kotlin/com/varabyte/kobweb/ksp/frontend/FrontendProcessor.kt
@@ -57,7 +57,7 @@ class FrontendProcessor(
     // We track all files we depend on so that ksp can perform smart recompilation
     // Even though our output is aggregating so generally requires full reprocessing, this at minimum means processing
     // will be skipped if the only change is deleted file(s) that we do not depend on.
-    val fileDependencies = mutableListOf<KSFile>()
+    private val fileDependencies = mutableListOf<KSFile>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
         kobwebInits += resolver.getSymbolsWithAnnotation(INIT_KOBWEB_FQN).map { annotatedFun ->
@@ -189,16 +189,26 @@ class FrontendProcessor(
 
     override fun finish() {
         val (path, extension) = genFile.split('.')
+        val (frontendData, fileDependencies) = getFinalizedData()
         codeGenerator.createNewFileByPath(
             Dependencies(aggregating = true, *fileDependencies.toTypedArray()),
             path = path,
             extensionName = extension,
         ).writer().use { writer ->
-            writer.write(Json.encodeToString(getData()))
+            writer.write(Json.encodeToString<FrontendData>(frontendData))
         }
     }
 
-    fun getData(): FrontendData {
+    /**
+     * Get the finalized metadata acquired over all rounds of processing.
+     *
+     * This function should only be called from [SymbolProcessor.finish] as it relies on all rounds of processing being
+     * complete.
+     *
+     * @return A pair consisting of the finalized FrontendData and a list of file dependencies that should be passed in
+     * when using KSP's [CodeGenerator] to store the data.
+     */
+    fun getFinalizedData(): Pair<FrontendData, List<KSFile>> {
         // pages are processed here as they rely on packageMappings, which may be populated over several rounds
         val pages = pageDeclarations.mapNotNull { annotatedFun ->
             processPagesFun(
@@ -231,6 +241,6 @@ class FrontendProcessor(
             it.assertValid(throwError = { msg -> logger.error(msg) })
         }
 
-        return frontendData
+        return frontendData to fileDependencies
     }
 }


### PR DESCRIPTION
This fixes an issue introduced by #444 where not-yet-complete file dependencies were being passed into KSP's codeGenerator, resulting in incomplete output upon recompilation. Now, the data and files are returned by a single function call, ensuring that the latter cannot be accessed prematurely.