### PR TITLE
Use standard source set names for generated directories

### DIFF
--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebCopySupplementalResourcesTask.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebCopySupplementalResourcesTask.kt
@@ -24,7 +24,7 @@ abstract class KobwebCopySupplementalResourcesTask @Inject constructor(
     fun getRuntimeClasspath() = project.configurations.named(project.jsTarget.runtimeClasspath)
 
     @OutputDirectory
-    fun getGenResDir() = kobwebBlock.getGenJsResRoot<AppBlock>(project).resolve("app")
+    fun getGenResDir() = kobwebBlock.getGenJsResRoot<AppBlock>(projectLayout).resolve("app")
 
     private fun getGenPublicRoot() = getGenResDir().resolve(kobwebBlock.publicPath.get())
 

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebCopyWorkerJsOutputTask.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebCopyWorkerJsOutputTask.kt
@@ -24,7 +24,7 @@ abstract class KobwebCopyWorkerJsOutputTask @Inject constructor(kobwebBlock: Kob
     fun getRuntimeClasspath() = project.configurations.named(project.jsTarget.runtimeClasspath)
 
     @OutputDirectory
-    fun getGenResDir() = kobwebBlock.getGenJsResRoot<AppBlock>(project).resolve("worker")
+    fun getGenResDir() = kobwebBlock.getGenJsResRoot<AppBlock>(projectLayout).resolve("worker")
 
     private fun getGenPublicRoot() = getGenResDir().resolve(kobwebBlock.publicPath.get())
 

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebGenerateApisFactoryTask.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebGenerateApisFactoryTask.kt
@@ -4,12 +4,10 @@ import com.varabyte.kobweb.gradle.application.extensions.AppBlock
 import com.varabyte.kobweb.gradle.application.templates.createApisFactoryImpl
 import com.varabyte.kobweb.gradle.core.extensions.KobwebBlock
 import com.varabyte.kobweb.gradle.core.kmp.jvmTarget
-import com.varabyte.kobweb.gradle.core.tasks.KobwebModuleTask
 import com.varabyte.kobweb.gradle.core.util.searchZipFor
 import com.varabyte.kobweb.ksp.KOBWEB_METADATA_BACKEND
 import com.varabyte.kobweb.project.backend.BackendData
 import com.varabyte.kobweb.project.backend.merge
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import org.gradle.api.GradleException
 import org.gradle.api.file.FileCollection
@@ -36,7 +34,7 @@ abstract class KobwebGenerateApisFactoryTask @Inject constructor(kobwebBlock: Ko
     } ?: DefaultProvider { project.objects.fileCollection() }
 
     @OutputDirectory // needs to be dir to be registered as a kotlin srcDir
-    fun getGenApisFactoryFile() = kobwebBlock.getGenJvmSrcRoot<AppBlock>(project)
+    fun getGenApisFactoryFile() = kobwebBlock.getGenJvmSrcRoot<AppBlock>(projectLayout)
 
     @TaskAction
     fun execute() {

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebGenerateSiteEntryTask.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebGenerateSiteEntryTask.kt
@@ -34,7 +34,7 @@ abstract class KobwebGenerateSiteEntryTask @Inject constructor(
     fun getCompileClasspath() = project.configurations.named(project.jsTarget.compileClasspath)
 
     @OutputDirectory // needs to be dir to be registered as a kotlin srcDir
-    fun getGenMainFile() = kobwebBlock.getGenJsSrcRoot<AppBlock>(project)
+    fun getGenMainFile() = kobwebBlock.getGenJsSrcRoot<AppBlock>(projectLayout)
 
     @TaskAction
     fun execute() {

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebGenerateSiteIndexTask.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebGenerateSiteIndexTask.kt
@@ -68,7 +68,7 @@ abstract class KobwebGenerateSiteIndexTask @Inject constructor(
     fun getCompileClasspath() = project.configurations.named(project.jsTarget.compileClasspath)
 
     @OutputFile
-    fun getGenIndexFile() = kobwebBlock.getGenJsResRoot<AppBlock>(project).resolve("index.html")
+    fun getGenIndexFile() = kobwebBlock.getGenJsResRoot<AppBlock>(projectLayout).resolve("index.html")
 
     @TaskAction
     fun execute() {

--- a/tools/gradle-plugins/core/src/main/kotlin/com/varabyte/kobweb/gradle/core/extensions/KobwebBlock.kt
+++ b/tools/gradle-plugins/core/src/main/kotlin/com/varabyte/kobweb/gradle/core/extensions/KobwebBlock.kt
@@ -2,10 +2,9 @@
 
 package com.varabyte.kobweb.gradle.core.extensions
 
-import com.varabyte.kobweb.gradle.core.kmp.jsTarget
-import com.varabyte.kobweb.gradle.core.kmp.jvmTarget
 import com.varabyte.kobweb.gradle.core.util.KobwebVersionUtil
 import org.gradle.api.Project
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.Property
 import org.gradle.kotlin.dsl.getByType
@@ -85,22 +84,19 @@ abstract class KobwebBlock : ExtensionAware {
         kspProcessorDependency.convention("com.varabyte.kobweb:kobweb-ksp-site-processors:${KobwebVersionUtil.version}")
     }
 
-    inline fun <reified T : FileGeneratingBlock> getGenJsSrcRoot(project: Project): File {
-        val jsSrcSuffix = project.jsTarget.srcSuffix
+    inline fun <reified T : FileGeneratingBlock> getGenJsSrcRoot(layout: ProjectLayout): File {
         val genDir = extensions.getByType<T>().genDir.get()
-        return project.layout.buildDirectory.dir("$genDir$jsSrcSuffix").get().asFile
+        return layout.buildDirectory.dir("$genDir/src/jsMain/kotlin").get().asFile
     }
 
-    inline fun <reified T : FileGeneratingBlock> getGenJsResRoot(project: Project): File {
-        val jsResourceSuffix = project.jsTarget.resourceSuffix
+    inline fun <reified T : FileGeneratingBlock> getGenJsResRoot(layout: ProjectLayout): File {
         val genDir = extensions.getByType<T>().genDir.get()
-        return project.layout.buildDirectory.dir("$genDir$jsResourceSuffix").get().asFile
+        return layout.buildDirectory.dir("$genDir/src/resources/kotlin").get().asFile
     }
 
-    inline fun <reified T : FileGeneratingBlock> getGenJvmSrcRoot(project: Project): File {
-        val jvmSrcSuffix = (project.jvmTarget ?: error("No JVM target defined")).srcSuffix
+    inline fun <reified T : FileGeneratingBlock> getGenJvmSrcRoot(layout: ProjectLayout): File {
         val genDir = extensions.getByType<T>().genDir.get()
-        return project.layout.buildDirectory.dir("$genDir$jvmSrcSuffix").get().asFile
+        return layout.buildDirectory.dir("$genDir/src/jvmMain/kotlin").get().asFile
     }
 }
 

--- a/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/tasks/ConvertMarkdownTask.kt
+++ b/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/tasks/ConvertMarkdownTask.kt
@@ -58,7 +58,7 @@ abstract class ConvertMarkdownTask @Inject constructor(
     abstract val generatedMarkdownDir: Property<File>
 
     @OutputDirectory
-    fun getGenDir(): File = kobwebBlock.getGenJsSrcRoot<MarkdownBlock>(project).resolve(
+    fun getGenDir(): File = kobwebBlock.getGenJsSrcRoot<MarkdownBlock>(projectLayout).resolve(
         project.prefixQualifiedPackage(kobwebBlock.pagesPackage.get()).replace(".", "/")
     )
 

--- a/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/tasks/ProcessMarkdownTask.kt
+++ b/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/tasks/ProcessMarkdownTask.kt
@@ -59,12 +59,12 @@ abstract class ProcessMarkdownTask @Inject constructor(
     }
 
     @OutputDirectory
-    fun getGenSrcDir(): File = kobwebBlock.getGenJsSrcRoot<MarkdownBlock>(project).resolve(
+    fun getGenSrcDir(): File = kobwebBlock.getGenJsSrcRoot<MarkdownBlock>(projectLayout).resolve(
         project.prefixQualifiedPackage(kobwebBlock.baseGenDir.get()).replace(".", "/")
     )
 
     @OutputDirectory
-    fun getGenResDir(): File = kobwebBlock.getGenJsResRoot<MarkdownBlock>(project)
+    fun getGenResDir(): File = kobwebBlock.getGenJsResRoot<MarkdownBlock>(projectLayout)
 
     @TaskAction
     fun execute() {


### PR DESCRIPTION
These do not have to match the names the user has chosen, since they are manually hooked up to the relevant gradle processes anyway. This helps avoid usages of "Task.project", which is incompatible with configuration cache.