### PR TITLE
Remove uses of assignment overload

### DIFF
--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/KobwebApplicationPlugin.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/KobwebApplicationPlugin.kt
@@ -54,7 +54,6 @@ import org.gradle.api.tasks.Sync
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.build.event.BuildEventsListenerRegistry
 import org.gradle.jvm.tasks.Jar
-import org.gradle.kotlin.dsl.assign
 import org.gradle.kotlin.dsl.extra
 import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.register
@@ -159,8 +158,10 @@ class KobwebApplicationPlugin @Inject constructor(
         }
 
         kobwebStartTask.configure {
-            serverJar = kobwebUnpackServerJarTask.map { it.getServerJar() }
-            serverPluginsDir = kobwebSyncServerPluginJarsTask.map { it.destinationDir }
+            serverJar.set(kobwebUnpackServerJarTask.map { RegularFile { it.getServerJar() } })
+            serverPluginsDir.set(kobwebSyncServerPluginJarsTask.map {
+                project.objects.directoryProperty().apply { set(it.destinationDir) }.get()
+            })
             doLast {
                 val devScript = kobwebConf.server.files.dev.script
                 if (env == ServerEnvironment.DEV && !project.file(devScript).exists()) {
@@ -198,7 +199,7 @@ class KobwebApplicationPlugin @Inject constructor(
             .register<KobwebExportTask>("kobwebExport", KobwebExportConfInputs(kobwebConf), exportLayout, kobwebBlock)
 
         project.tasks.register<KobwebBrowserCacheIdTask>("kobwebBrowserCacheId") {
-            browser = kobwebBlock.app.export.browser
+            browser.set(kobwebBlock.app.export.browser)
         }
 
         // Note: I'm pretty sure I'm abusing build service tasks by adding a listener to it directly but I'm not sure

--- a/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/KobwebxMarkdownPlugin.kt
+++ b/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/KobwebxMarkdownPlugin.kt
@@ -10,7 +10,6 @@ import com.varabyte.kobwebx.gradle.markdown.tasks.ProcessMarkdownTask
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.assign
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
@@ -38,11 +37,11 @@ class KobwebxMarkdownPlugin : Plugin<Project> {
             val jsTarget = JsTarget(this)
 
             processTask.configure {
-                resources = project.getResourceSources(jsTarget)
+                resources.set(project.getResourceSources(jsTarget))
             }
             convertTask.configure {
-                resources = project.getResourceSources(jsTarget)
-                generatedMarkdownDir = processTask.map { it.getGenResDir() }
+                resources.set(project.getResourceSources(jsTarget))
+                generatedMarkdownDir.set(processTask.map { it.getGenResDir() })
             }
 
             project.kotlin.sourceSets.named(jsTarget.mainSourceSet) {

--- a/tools/gradle-plugins/library/src/main/kotlin/com/varabyte/kobweb/gradle/library/KobwebLibraryPlugin.kt
+++ b/tools/gradle-plugins/library/src/main/kotlin/com/varabyte/kobweb/gradle/library/KobwebLibraryPlugin.kt
@@ -24,7 +24,6 @@ import com.varabyte.kobweb.gradle.library.tasks.KobwebGenerateLibraryMetadataTas
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.kotlin.dsl.assign
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrTarget
@@ -43,7 +42,7 @@ class KobwebLibraryPlugin : Plugin<Project> {
             project.tasks.register<KobwebGenerateIndexMetadataTask>("kobwebGenerateIndexMetadata")
         val kobwebGenerateLibraryMetadataTask = project.tasks
             .register<KobwebGenerateLibraryMetadataTask>("kobwebGenerateLibraryMetadata") {
-                indexHead = project.kobwebBlock.library.index.head
+                indexHead.set(project.kobwebBlock.library.index.head)
             }
         project.buildTargets.withType<KotlinJsIrTarget>().configureEach {
             val jsTarget = JsTarget(this)


### PR DESCRIPTION
This restores compatability with older gradle version.