### PR TITLE
Specify roles of custom gradle configurations

### DIFF
--- a/tools/gradle-plugins/application/build.gradle.kts
+++ b/tools/gradle-plugins/application/build.gradle.kts
@@ -45,7 +45,10 @@ kobwebPublication {
     description.set(DESCRIPTION)
 }
 
-val serverJar by configurations.registering { isTransitive = false }
+val serverJar by configurations.registering {
+    isCanBeConsumed = false
+    isTransitive = false
+}
 dependencies {
     @Suppress("UnstableApiUsage")
     serverJar(project(projects.backend.server.dependencyProject.path, configuration = "shadow"))

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/KobwebApplicationPlugin.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/KobwebApplicationPlugin.kt
@@ -88,6 +88,7 @@ class KobwebApplicationPlugin @Inject constructor(
         // A Kobweb Server Plugin is one which is loaded by the Kobweb server when it starts up. It's a way for users to
         // configure their ktor server in ways that Kobweb does not currently expose.
         project.configurations.register(KOBWEB_SERVER_PLUGIN_CONFIGURATION_NAME) {
+            isCanBeConsumed = false
             isTransitive = false
         }
 


### PR DESCRIPTION
The default behavior, where `isCanBeConsumed` and `isCanBeResolved` are both true, is deprecated.