### PR TITLE
Add a Gradle task which lists all routes defined by the current site

### DIFF
--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebCacheFrontendDataTask.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebCacheFrontendDataTask.kt
@@ -1,0 +1,49 @@
+package com.varabyte.kobweb.gradle.application.tasks
+
+import com.varabyte.kobweb.gradle.core.util.searchZipFor
+import com.varabyte.kobweb.ksp.KOBWEB_METADATA_FRONTEND
+import com.varabyte.kobweb.project.frontend.AppData
+import com.varabyte.kobweb.project.frontend.FrontendData
+import com.varabyte.kobweb.project.frontend.merge
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+// NOTE: This task in meant as an internal API so it does not inherit from KobwebTask
+abstract class KobwebCacheFrontendDataTask : DefaultTask() {
+    init {
+        description = "Search the project and merge all frontend data, saving it into a file, at which point it can be looked up by downstream tasks that need it."
+    }
+
+    @get:InputFile
+    abstract val appFrontendMetadataFile: RegularFileProperty
+
+    @get:InputFiles
+    abstract val compileClasspath: ConfigurableFileCollection
+
+    @get:OutputFile
+    abstract val frontendDataFile: RegularFileProperty
+
+    @TaskAction
+    fun execute() {
+        val appData = Json.decodeFromString<AppData>(appFrontendMetadataFile.get().asFile.readText())
+        val frontendData = buildList {
+            add(appData.frontendData)
+            compileClasspath.forEach { file ->
+                file.searchZipFor(KOBWEB_METADATA_FRONTEND) { bytes ->
+                    add(Json.decodeFromString<FrontendData>(bytes.decodeToString()))
+                }
+            }
+        }
+            .merge(throwError = { throw GradleException(it) })
+
+        frontendDataFile.get().asFile.writeText(Json.encodeToString(frontendData))
+    }
+}

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebListRoutesTask.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebListRoutesTask.kt
@@ -1,0 +1,26 @@
+package com.varabyte.kobweb.gradle.application.tasks
+
+import com.varabyte.kobweb.gradle.core.tasks.KobwebTask
+import com.varabyte.kobweb.project.frontend.FrontendData
+import kotlinx.serialization.json.Json
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.TaskAction
+
+abstract class KobwebListRoutesTask : KobwebTask("Enumerate all routes for your site managed by Kobweb") {
+    @get:InputFile
+    abstract val frontendDataFile: RegularFileProperty
+
+    @TaskAction
+    fun execute() {
+        val pageEntries = Json.decodeFromString<FrontendData>(frontendDataFile.asFile.get().readText()).pages
+        if (pageEntries.isNotEmpty()) {
+            println("Your site defines the following routes:")
+            pageEntries.map { it.route }.sorted().forEach { route ->
+                println("  $route")
+            }
+        } else {
+            println("No routes have been defined in your project yet.")
+        }
+    }
+}


### PR DESCRIPTION
While doing this, refactor some code out of "export" into a separate task so that both tasks can share code.