### PR TITLE
Hardcode the "public/" path for now

### DIFF
--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/KobwebApplicationPlugin.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/KobwebApplicationPlugin.kt
@@ -312,7 +312,6 @@ class KobwebApplicationPlugin @Inject constructor(
 
             // configure both kobwebCopySupplementalResourcesTask & kobwebCopyWorkerJsOutputTask
             project.tasks.withType<KobwebCopyTask>().configureEach {
-                publicPath.set(kobwebBlock.publicPath)
                 runtimeClasspath.from(project.configurations.named(jsTarget.runtimeClasspath))
             }
 

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebCopySupplementalResourcesTask.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebCopySupplementalResourcesTask.kt
@@ -17,7 +17,7 @@ abstract class KobwebCopySupplementalResourcesTask @Inject constructor(
     @OutputDirectory
     fun getGenResDir() = appBlock.getGenJsResRoot("supplemental")
 
-    private fun getGenPublicRoot() = getGenResDir().get().asFile.resolve(publicPath.get())
+    private fun getGenPublicRoot() = getGenResDir().get().asFile.resolve("public")
 
     @TaskAction
     fun execute() {

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebCopyTask.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebCopyTask.kt
@@ -10,8 +10,6 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.file.FileTree
 import org.gradle.api.model.ObjectFactory
-import org.gradle.api.provider.Property
-import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.util.PatternSet
 import java.io.File
@@ -29,9 +27,6 @@ abstract class KobwebCopyTask(desc: String) : KobwebTask(desc) {
 
     @get:Inject
     abstract val archiveOperations: ArchiveOperations
-
-    @get:Input
-    abstract val publicPath: Property<String>
 
     @get:InputFiles
     abstract val runtimeClasspath: ConfigurableFileCollection

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebCopyWorkerJsOutputTask.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebCopyWorkerJsOutputTask.kt
@@ -19,7 +19,7 @@ abstract class KobwebCopyWorkerJsOutputTask @Inject constructor(private val appB
     @OutputDirectory
     fun getGenResDir() = appBlock.getGenJsResRoot("worker")
 
-    private fun getGenPublicRoot() = getGenResDir().get().asFile.resolve(publicPath.get())
+    private fun getGenPublicRoot() = getGenResDir().get().asFile.resolve("public")
 
     @TaskAction
     fun execute() {

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebExportTask.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebExportTask.kt
@@ -367,8 +367,7 @@ abstract class KobwebExportTask @Inject constructor(
         // export layouts but shouldn't be copied over in static layouts as those should only include pages explicitly
         // defined by the site.
         getResourceFilesJsWithRoots().forEach { rootAndFile ->
-            // Drop the leading slash so we don't confuse File resolve logic
-            val relativePath = rootAndFile.relativeFile.invariantSeparatorsPath.substringAfter(getPublicPath()).drop(1)
+            val relativePath = rootAndFile.relativeFile.invariantSeparatorsPath.substringAfter("public/")
             if (relativePath == "index.html" && siteLayout != SiteLayout.KOBWEB) return@forEach
 
             (if (relativePath != "index.html") resourcesRoot else systemRoot)

--- a/tools/gradle-plugins/core/src/main/kotlin/com/varabyte/kobweb/gradle/core/extensions/KobwebBlock.kt
+++ b/tools/gradle-plugins/core/src/main/kotlin/com/varabyte/kobweb/gradle/core/extensions/KobwebBlock.kt
@@ -61,12 +61,6 @@ abstract class KobwebBlock : ExtensionAware {
      */
     abstract val apiPackage: Property<String>
 
-    /**
-     * The path of public resources inside the project's resources folder, e.g. "public" ->
-     * "src/jsMain/resources/public"
-     */
-    abstract val publicPath: Property<String>
-
     /** The KSP processor dependency that should be applied to the project, in string dependency notation. */
     abstract val kspProcessorDependency: Property<String>
 
@@ -78,7 +72,6 @@ abstract class KobwebBlock : ExtensionAware {
         }
         pagesPackage.convention(".pages")
         apiPackage.convention(".api")
-        publicPath.convention("public")
         kspProcessorDependency.convention("com.varabyte.kobweb:kobweb-ksp-site-processors:${KobwebVersionUtil.version}")
     }
 }

--- a/tools/gradle-plugins/core/src/main/kotlin/com/varabyte/kobweb/gradle/core/tasks/KobwebModuleTask.kt
+++ b/tools/gradle-plugins/core/src/main/kotlin/com/varabyte/kobweb/gradle/core/tasks/KobwebModuleTask.kt
@@ -4,7 +4,6 @@ import com.varabyte.kobweb.gradle.core.extensions.KobwebBlock
 import com.varabyte.kobweb.gradle.core.kmp.jsTarget
 import com.varabyte.kobweb.gradle.core.util.RootAndFile
 import com.varabyte.kobweb.gradle.core.util.getResourceFilesWithRoots
-import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 
 /**
@@ -13,12 +12,5 @@ import org.gradle.api.tasks.Internal
 abstract class KobwebModuleTask(@get:Internal val kobwebBlock: KobwebBlock, desc: String) : KobwebTask(desc) {
     @Internal
     fun getResourceFilesJsWithRoots(): Sequence<RootAndFile> = project.getResourceFilesWithRoots(project.jsTarget)
-        .filter { rootAndFile -> rootAndFile.relativeFile.invariantSeparatorsPath.startsWith("${getPublicPath()}/") }
-
-    /**
-     * The path of public resources inside the project's resources folder, e.g. "public" ->
-     * "src/jsMain/resources/public"
-     */
-    @Input
-    fun getPublicPath(): String = kobwebBlock.publicPath.get()
+        .filter { rootAndFile -> rootAndFile.relativeFile.invariantSeparatorsPath.startsWith("public/") }
 }


### PR DESCRIPTION
This lets us delete some code and simplify other paths as a result.

This is part of a bigger change, to move the "pagesPackage", "apiPackage", and "publicPath" Gradle properties out of the root Kobweb block (as they don't belong there, especially since we now have `app`, `server`, and `library` blocks).

While I was looking at the public path property, I realize we hardcode "public/" in some places and allow it to be overridden in others. The task for copying supplemental resources from libraries is a great example.

It seems unlikely ANYONE is using this right now, so for now, we just remove it. Maybe we can add it back again in the future, if requested -- but we'll need to think about how to handle this in libraries, where they can also specify their own resources, and they too should have a say. But if they do, then the app has to respect their setting and use it. This seems like a lot of complexity for no requested benefit.