### PR TITLE
Add sensible casting to Breakpoint extension functions

### DIFF
--- a/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/style/breakpoint/BreakpointValues.kt
+++ b/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/style/breakpoint/BreakpointValues.kt
@@ -1,5 +1,6 @@
 package com.varabyte.kobweb.silk.components.style.breakpoint
 
+import com.varabyte.kobweb.compose.css.*
 import kotlinx.browser.window
 import org.jetbrains.compose.web.css.*
 import org.w3c.dom.Window
@@ -13,7 +14,7 @@ private val Window.bodyFontSize: Number
     }
 
 
-sealed class BreakpointUnitValue<out T : CSSUnitValue>(val width: T) {
+sealed class BreakpointUnitValue<out T : CSSLengthNumericValue>(val width: T) {
     abstract fun toPx(): CSSpxValue
 
     class Px(value: CSSpxValue) : BreakpointUnitValue<CSSpxValue>(value) {
@@ -38,7 +39,7 @@ sealed class BreakpointUnitValue<out T : CSSUnitValue>(val width: T) {
 /**
  * A class used for storing generic values associated with breakpoints.
  */
-data class BreakpointValues<out T : CSSUnitValue>(
+data class BreakpointValues<out T : CSSLengthNumericValue>(
     val sm: BreakpointUnitValue<T>,
     val md: BreakpointUnitValue<T>,
     val lg: BreakpointUnitValue<T>,

--- a/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/style/breakpoint/BreakpointValues.kt
+++ b/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/style/breakpoint/BreakpointValues.kt
@@ -80,10 +80,10 @@ fun BreakpointSizes(
  * A convenience class for constructing an association of breakpoints to CSS rem sizes.
  */
 fun BreakpointSizes(
-    sm: CSSSizeValue<CSSUnit.rem> = 0.cssRem,
-    md: CSSSizeValue<CSSUnit.rem> = sm,
-    lg: CSSSizeValue<CSSUnit.rem> = md,
-    xl: CSSSizeValue<CSSUnit.rem> = lg,
+    sm: CSSSizeValue<CSSUnit.rem>,
+    md: CSSSizeValue<CSSUnit.rem>,
+    lg: CSSSizeValue<CSSUnit.rem>,
+    xl: CSSSizeValue<CSSUnit.rem>,
 ) = BreakpointValues(
     BreakpointUnitValue.Rem(sm),
     BreakpointUnitValue.Rem(md),

--- a/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/theme/SilkTheme.kt
+++ b/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/theme/SilkTheme.kt
@@ -1,6 +1,7 @@
 package com.varabyte.kobweb.silk.theme
 
 import androidx.compose.runtime.*
+import com.varabyte.kobweb.compose.css.*
 import com.varabyte.kobweb.compose.ui.Modifier
 import com.varabyte.kobweb.silk.components.style.ComponentBaseModifier
 import com.varabyte.kobweb.silk.components.style.ComponentModifier
@@ -37,7 +38,7 @@ class MutableSilkTheme {
     val palettes = MutablePalettes()
     internal val legacyPalettes = LegacyMutableSilkPalettes(palettes)
 
-    var breakpoints: BreakpointValues<CSSUnitValue> = BreakpointSizes(
+    var breakpoints: BreakpointValues<CSSLengthNumericValue> = BreakpointSizes(
         30.cssRem,
         48.cssRem,
         62.cssRem,

--- a/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/theme/breakpoint/BreakpointExtensions.kt
+++ b/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/theme/breakpoint/BreakpointExtensions.kt
@@ -1,12 +1,13 @@
 package com.varabyte.kobweb.silk.theme.breakpoint
 
+import com.varabyte.kobweb.compose.css.*
 import com.varabyte.kobweb.silk.components.style.breakpoint.Breakpoint
 import com.varabyte.kobweb.silk.components.style.breakpoint.BreakpointUnitValue
 import com.varabyte.kobweb.silk.theme.SilkTheme
 import org.jetbrains.compose.web.css.*
 import org.w3c.dom.Window
 
-private fun Breakpoint.toValue(): BreakpointUnitValue<CSSUnitValue>? {
+private fun Breakpoint.toValue(): BreakpointUnitValue<CSSLengthNumericValue>? {
     return when (this) {
         Breakpoint.ZERO -> null
         Breakpoint.SM -> SilkTheme.breakpoints.sm
@@ -19,14 +20,14 @@ private fun Breakpoint.toValue(): BreakpointUnitValue<CSSUnitValue>? {
 /**
  * Convenience method for fetching the associated `SilkTheme.breakpoints` value for the current [Breakpoint] value.
  */
-fun Breakpoint.toWidth(): CSSUnitValue {
-    return this.toValue()?.width ?: 0.px
+fun Breakpoint.toWidth(): CSSLengthNumericValue {
+    return (this.toValue()?.width ?: 0.px)
 }
 
 /**
  * Convenience method for fetching the associated `SilkTheme.breakpoints` value for the current [Breakpoint] value.
  */
-fun Breakpoint.toPx(): CSSUnitValue {
+fun Breakpoint.toPx(): CSSpxValue {
     return this.toValue()?.toPx() ?: 0.px
 }
 


### PR DESCRIPTION
This way, a user can use

```
Modifier.width(Breakpoint.LG.toWidth())
```

which it really seems like someone should be able to do.