### PR TITLE
Update README.md of silk-icons-fa module to fix a typo

### DIFF
--- a/frontend/silk-icons-fa/README.md
+++ b/frontend/silk-icons-fa/README.md
@@ -17,7 +17,7 @@ this project.
 
 To populate it, I visited the
 [Font Awesome free icon search](https://fontawesome.com/search?o=a&m=free&f=classic%2Cbrands), inspected the site using
-dev tools, and visited each of the 12 pages, copying the DOM subtree under the `<div id="icon-results">` element into a
+dev tools, and visited each of the 12 pages, copying the DOM subtree under the `<div id="icons-results">` element into a
 temporary text file.
 
 I then manually reorganized the results (into solid, regular, and brand subsets) and migrated the XML format into the


### PR DESCRIPTION
Update README.md of the `silk-icons-fa` module to fix a typo in the div class

![image](https://github.com/varabyte/kobweb/assets/73608287/0ba0635b-2ee6-495b-b5ae-e89f21f92bb5)

Image from @bitspittle 