### PR TITLE
Fix overflow issues caused by hidden inputs

### DIFF
--- a/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/forms/Checkbox.kt
+++ b/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/forms/Checkbox.kt
@@ -88,6 +88,7 @@ val CheckboxStyle by ComponentStyle(
             .userSelect(UserSelect.None)
             .fontSize(CheckboxVars.FontSize.value())
             .cursor(Cursor.Pointer)
+            .position(Position.Relative) // So the hidden <input> is positioned relative to the checkbox root
     }
 }
 

--- a/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/forms/Input.kt
+++ b/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/forms/Input.kt
@@ -53,6 +53,10 @@ import org.w3c.dom.HTMLInputElement
  * We have several widgets which wrap an input but provide their own custom rendering. In this case, we still want to do
  * some tricks which keep the final widget a11y-friendly by only limiting its size/appearance (instead of explicitly
  * hiding it). This matches the approach of many other JS libraries out there.
+ *
+ * Note that this uses `Position.Absolute`, which positions the element relative to the closest non-static ancestor.
+ * This ancestor should generally be part of the same component, often a `Label` with `Position.Relative`, to avoid
+ * unintended effects on the larger layout.
  */
 internal val HiddenInputModifier = Modifier
     .border(0.px)

--- a/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/forms/Switch.kt
+++ b/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/forms/Switch.kt
@@ -46,12 +46,14 @@ object SwitchVars {
     val TransitionDuration by StyleVariable(prefix = "silk", defaultFallback = TransitionDurationVars.Fast.value())
 }
 
-val SwitchStyle by ComponentStyle(prefix = "silk") {}
+val SwitchStyle by ComponentStyle.base(prefix = "silk") {
+    Modifier
+        .position(Position.Relative) // So the hidden <input> is positioned relative to the switch root
+}
 
 val SwitchTrackStyle by ComponentStyle(prefix = "silk", extraModifiers = Modifier.tabIndex(-1).ariaHidden()) {
     base {
         Modifier
-            .position(Position.Relative) // So input can be positioned absolutely without affecting the layout
             .width(SwitchVars.TrackWidth.value())
             .minWidth(SwitchVars.TrackWidth.value())
             .height(SwitchVars.TrackHeight.value())


### PR DESCRIPTION
The input was being positioned relative to the entire html body, causing undesired layout overflows in some situations. This change adds `position: relative` to the relevant parent `Label`s, following the practice of other JS libraries.