### PR TITLE
Fix convenience function for excluding tags from specific dependencies

### DIFF
--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/extensions/AppBlock.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/extensions/AppBlock.kt
@@ -128,10 +128,10 @@ abstract class AppBlock @Inject constructor(
          *   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
          *   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css">
          *   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css">
-         * Add `kobweb { app { index { excludeTagsForDependency("kotlin-bootstrap") } } }` to your build.gradle.kts file to opt-out.
+         * Add `kobweb { app { index { excludeTagsForDependencies("kotlin-bootstrap", /* "other-dependency" */) } } }` to your build.gradle.kts file to opt-out.
          * ```
          *
-         * You can use [excludeTagsForDependency], or you can handle it yourself by using [excludeTags] directly:
+         * You can use [excludeTagsForDependencies], or you can handle it yourself by using [excludeTags] directly:
          *
          * ```
          * excludeTags.set { name.startsWith("kotlin-bootstrap") }
@@ -468,7 +468,7 @@ internal fun KobwebBlock.createAppBlock(kobwebFolder: KobwebFolder, conf: Kobweb
  * When Kobweb detects a dependency that adds head elements, it will print a warning message that includes the value
  * of the artifact name which you can use here.
  */
-fun AppBlock.IndexBlock.excludeTagsForDependency(vararg dependencyNamePrefixes: String) {
+fun AppBlock.IndexBlock.excludeTagsForDependencies(vararg dependencyNamePrefixes: String) {
     excludeTags.set {
         dependencyNamePrefixes.any { name.startsWith(it) }
     }

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/extensions/AppBlock.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/extensions/AppBlock.kt
@@ -458,21 +458,19 @@ internal fun KobwebBlock.createAppBlock(kobwebFolder: KobwebFolder, conf: Kobweb
 }
 
 /**
- * A convenience method for the common case of specifying a direct dependency with the [excludeTags][AppBlock.IndexBlock.excludeTags] method.
+ * A convenience method for the common case of specifying direct dependencies for the
+ * [excludeTags][AppBlock.IndexBlock.excludeTags] property.
  *
- * The value passed into this method is a prefix, so for example, the names "kotlin-bootstrap", "kotlin-bootstrap-js",
+ * The values passed into this method are prefixes, so for example, the names "kotlin-bootstrap", "kotlin-bootstrap-js",
  * "kotlin-bootstrap-js-1.0", and "kotlin-bootstrap-js-1.0.klib" would all work to opt-out of accepting head elements
  * from the "kotlin-bootstrap-js-1.0.klib" artifact.
  *
  * When Kobweb detects a dependency that adds head elements, it will print a warning message that includes the value
  * of the artifact name which you can use here.
- *
- * If you call this method multiple times with different dependencies, the effect is additive.
  */
-fun AppBlock.IndexBlock.excludeTagsForDependency(dependencyNamePrefix: String) {
+fun AppBlock.IndexBlock.excludeTagsForDependency(vararg dependencyNamePrefixes: String) {
     excludeTags.set {
-        val ctx = this
-        name.startsWith(dependencyNamePrefix) || excludeTags.get().invoke(ctx)
+        dependencyNamePrefixes.any { name.startsWith(it) }
     }
     excludeTags.disallowChanges()
 }

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebGenerateSiteIndexTask.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebGenerateSiteIndexTask.kt
@@ -149,7 +149,7 @@ abstract class KobwebGenerateSiteIndexTask @Inject constructor(
                             appendLine("Dependency artifact \"${file.name}\" will add the following <head> elements to your site's index.html:")
                             appendLine(headElements.joinToString("\n") { "   " + it.outerHtml() })
                             append(
-                                "Add `kobweb { app { index { excludeTagsForDependency(\"${
+                                "Add `kobweb { app { index { excludeTagsForDependencies(\"${
                                     file.nameWithoutExtension.substringBeforeLast("-js-")
                                 }\") } } }` to your build.gradle.kts file to opt-out."
                             )


### PR DESCRIPTION
The previous implementation was broken in two ways when called multiple times, this is now fixed by accepting multiple values in a single call.