### PR TITLE
Fix breaking the "no root" markdown case

### DIFF
--- a/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/KobwebxMarkdownPlugin.kt
+++ b/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/KobwebxMarkdownPlugin.kt
@@ -11,7 +11,6 @@ import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.create
-import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.targets.js.ir.KotlinJsIrTarget
@@ -24,7 +23,7 @@ class KobwebxMarkdownPlugin : Plugin<Project> {
 
         val markdownBlock = kobwebBlock.extensions.create<MarkdownBlock>("markdown", kobwebBlock.baseGenDir)
         markdownBlock.extensions.apply {
-            create<MarkdownHandlers>("handlers", project)
+            create<MarkdownHandlers>("handlers", project, markdownBlock.defaultRoot)
             create<MarkdownFeatures>("features")
         }
 
@@ -53,18 +52,11 @@ class KobwebxMarkdownPlugin : Plugin<Project> {
         }
 
         // Handle deprecation warnings
-        @Suppress("DEPRECATION")
         project.afterEvaluate {
+            @Suppress("DEPRECATION")
             if (markdownBlock.routeOverride.isPresent) {
                 project.logger.warn(
                     "w: The markdown `markdown.routeOverride` property is slated for removal. It was introduced to support kebab-case URLs, but Kobweb has moved to defaulting to them instead."
-                )
-            }
-
-            val markdownHandlers = markdownBlock.extensions.getByType<MarkdownHandlers>()
-            if (markdownHandlers.defaultRoot.isPresent) {
-                project.logger.warn(
-                    "w: The `markdown.handlers.defaultRoot` property has moved to the parent markdown block instead, and this property is slated for removal. Use `markdown { defaultRoot.set(...) }` instead."
                 )
             }
         }

--- a/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/MarkdownBlock.kt
+++ b/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/MarkdownBlock.kt
@@ -50,7 +50,8 @@ abstract class MarkdownBlock(baseGenDir: Provider<String>) : KobwebBlock.FileGen
      *
      * Note that a user might have overridden the Kobweb default root layout via the `@App` annotation, in which case,
      * they may not need to specify a root at all here (since that could just add an unnecessary extra layer to the DOM
-     * tree). To indicate this (expectedly rare) case, this value may be set to the empty string to disable it.
+     * tree). To indicate this (expectedly rare) case, this value may be set to the empty string (or `null as String?`)
+     * to disable it.
      */
     abstract val defaultRoot: Property<String>
 
@@ -160,6 +161,7 @@ abstract class MarkdownBlock(baseGenDir: Provider<String>) : KobwebBlock.FileGen
 
     init {
         markdownPath.convention("markdown")
+        defaultRoot.convention("com.varabyte.kobweb.compose.foundation.layout.Column")
         imports.set(emptyList())
         genDir.convention(baseGenDir.map { "$it/markdown" })
     }

--- a/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/MarkdownHandlers.kt
+++ b/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/MarkdownHandlers.kt
@@ -73,7 +73,7 @@ class NodeScope(val data: TypedMap, private val indentCountBase: Int = 0) {
  * }
  * ```
  */
-abstract class MarkdownHandlers @Inject constructor(project: Project) {
+abstract class MarkdownHandlers @Inject constructor(project: Project, newDefaultRoot: Property<String>) {
     companion object {
         /** Key used by [Heading] nodes to store IDs they generated for themselves. */
         val HeadingIdsKey = Key.create<MutableMap<Heading, String>>("md.heading.ids")
@@ -92,7 +92,7 @@ abstract class MarkdownHandlers @Inject constructor(project: Project) {
      * tree). To indicate this (expectedly rare) case, this value may be set to the empty string to disable it.
      */
     @Deprecated("Use the `defaultRoot` property in the parent markdown block instead.")
-    abstract val defaultRoot: Property<String>
+    val defaultRoot: Property<String> = newDefaultRoot
 
     /**
      * Use Silk components instead of Compose HTML components when relevant.

--- a/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/tasks/ConvertMarkdownTask.kt
+++ b/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/tasks/ConvertMarkdownTask.kt
@@ -106,13 +106,6 @@ abstract class ConvertMarkdownTask @Inject constructor(private val markdownBlock
                 @Suppress("DEPRECATION")
                 val funName = "${ktFileName.capitalize()}Page"
 
-                // Until we remove markdownHandlers.defaultRoot, support the case where a user set the legacy property
-                // and not the main property. When markdownHandlers.defaultRoot is removed, this if block can be deleted.
-                @Suppress("DEPRECATION")
-                if (markdownHandlers.defaultRoot.isPresent) {
-                    markdownBlock.defaultRoot.convention(markdownHandlers.defaultRoot)
-                }
-
                 val ktRenderer = KotlinRenderer(
                     project,
                     cache::getRelative,

--- a/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/tasks/ConvertMarkdownTask.kt
+++ b/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/tasks/ConvertMarkdownTask.kt
@@ -106,10 +106,17 @@ abstract class ConvertMarkdownTask @Inject constructor(private val markdownBlock
                 @Suppress("DEPRECATION")
                 val funName = "${ktFileName.capitalize()}Page"
 
+                // Until we remove markdownHandlers.defaultRoot, support the case where a user set the legacy property
+                // and not the main property. When markdownHandlers.defaultRoot is removed, this if block can be deleted.
+                @Suppress("DEPRECATION")
+                if (markdownHandlers.defaultRoot.isPresent) {
+                    markdownBlock.defaultRoot.convention(markdownHandlers.defaultRoot)
+                }
+
                 val ktRenderer = KotlinRenderer(
                     project,
                     cache::getRelative,
-                    markdownBlock.defaultRoot.orNull ?: @Suppress("DEPRECATION") markdownHandlers.defaultRoot.orNull,
+                    markdownBlock.defaultRoot.orNull?.takeUnless { it.isBlank() },
                     markdownBlock.imports.get(),
                     mdPathRel,
                     markdownHandlers,


### PR DESCRIPTION
The previous code used to handle users disabling the "no root" markdown case by setting it to "", but I broke that with a previous code change. This has now been fixed.