### PR TITLE
Update build.yml to use Gradle Caching and build timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v4
@@ -18,6 +19,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 11
+          cache: gradle
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3


### PR DESCRIPTION
See this [link](https://github.com/actions/setup-java?tab=readme-ov-file#caching-gradle-dependencies)
the timeout in case there is a infinite loop or some build bug (or if it's stuck for some reason) so it won't work forever, there is a limit (it's higher in public/open source projects)