### PR TITLE
Update build.yml to add timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Sometimes (it happened with me twice) the workflow keep running forever, it can because of a bug, infinite loop or some mistake in the configurations etc...

To avoid the limit issues (it's higher in public/open source projects) and also to not unnecessarily cost GitHub,  it's better to add timeout (which I think there should be by default lower and give the option to disable it or make it higher, see [this](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes) for more info), we might also increase it to 10 if the build & test process take longer