### PR TITLE
Fix `display-if-at-least-*` classes

### DIFF
--- a/frontend/browser-ext/src/jsMain/kotlin/com/varabyte/kobweb/browser/dom/css/CSSLayerBlockRule.kt
+++ b/frontend/browser-ext/src/jsMain/kotlin/com/varabyte/kobweb/browser/dom/css/CSSLayerBlockRule.kt
@@ -1,0 +1,10 @@
+package com.varabyte.kobweb.browser.dom.css
+
+import org.w3c.dom.css.CSSGroupingRule
+
+/**
+ * Exposes the JavaScript [CSSLayerBlockRule](https://developer.mozilla.org/docs/Web/API/CSSLayerBlockRule) to Kotlin
+ */
+sealed external class CSSLayerBlockRule : CSSGroupingRule {
+    val name: String
+}


### PR DESCRIPTION
The previous logic broke after the styles were moved inside a CSS layer.