### PR TITLE
Create update-gradle-wrapper.yml to automate the process of updating Gradle wrapper

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -1,0 +1,15 @@
+name: Update Gradle Wrapper
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  update-gradle-wrapper:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Update Gradle Wrapper
+        uses: gradle-update/update-gradle-wrapper-action@v1


### PR DESCRIPTION
This PR doesn't do anything, it use all the code from [Update Gradle Wrapper Action](https://github.com/marketplace/actions/update-gradle-wrapper-action) from the GitHub marketplace, we often have too many versions for different tools and dependencies, this would make the process of keep tracking of all of them and ensuring them they are up to date to benefit from latest bug fixes, improvements, features and security fixes is a more time consuming and sometimes we forgot about them

If you read this [link](https://github.com/marketplace/actions/update-gradle-wrapper-action#hygiene):

>Gradle is under heavy development, with new releases available every few weeks. Projects that stick to old Wrapper versions can't > benefit from the tons of features and bug fixes being rolled out.
> 
> Updating the build system only once or twice per year might become a tedious task. You will need to walk through longer changelogs > and handle any breaking change. Updating frequently helps do less work, take advantage of new features earlier and safely drop > deprecated functionality.
>
> This action runs automatically at the declared schedule and creates Pull Requests with detailed information about the version update.


It won't automatically update the Gradle wrapper version, it will send a PR and have to manually accept or reject the change, and it will be scheduled