### PR TITLE
Add support for multiple box shadows on BoxShadow Modifier API

### DIFF
--- a/frontend/compose-html-ext/src/jsMain/kotlin/com/varabyte/kobweb/compose/css/Box.kt
+++ b/frontend/compose-html-ext/src/jsMain/kotlin/com/varabyte/kobweb/compose/css/Box.kt
@@ -40,11 +40,12 @@ class BoxSizing private constructor(private val value: String) : StylePropertyVa
     }
 }
 
+// See: https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing
 fun StyleScope.boxSizing(boxSizing: BoxSizing) {
     boxSizing(boxSizing.toString())
 }
 
-// See: https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing
+// See: https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow
 fun StyleScope.boxShadow(value: String) {
     property("box-shadow", value)
 }
@@ -57,32 +58,207 @@ fun StyleScope.boxShadow(
     color: CSSColorValue? = null,
     inset: Boolean = false,
 ) {
-    boxShadow(buildString {
-        if (inset) {
-            append("inset")
-            append(' ')
-        }
-        append(offsetX)
-        append(' ')
-        append(offsetY)
+    boxShadow(
+        BoxShadow.of(
+            offsetX = offsetX,
+            offsetY = offsetY,
+            blurRadius = blurRadius,
+            spreadRadius = spreadRadius,
+            color = color,
+            inset = inset,
+        ),
+    )
+}
 
-        if (blurRadius != null) {
-            append(' ')
-            append(blurRadius)
-        }
+/**
+ * Creates a box-shadow property with a single shadow.
+ * The property accepts either the [BoxShadow.None] value, the
+ * default global keywords, which indicates no shadows, or a
+ * list of shadows, created by using [BoxShadow.of], ordered
+ * front to back.
+ *
+ * Usages:
+ * ```kotlin
+ * style {
+ *     boxShadow(BoxShadow.None)
+ * }
+ * ```
+ * Will generate:
+ * ```css
+ * box-shadow: none
+ * ```
+ *
+ * ```kotlin
+ * style {
+ *     boxShadow(BoxShadow.Unset)
+ * }
+ * ```
+ * Will generate:
+ * ```css
+ * box-shadow: unset
+ * ```
+ * ```kotlin
+ * style {
+ *     boxShadow(
+ *         BoxShadow.of(
+ *             offsetX = 0.px,
+ *             offsetY = 1.px,
+ *             blurRadius = 3.px,
+ *             spreadRadius = 1.px,
+ *             color = Colors.Black.copyf(alpha = 0.15f),
+ *         ),
+ *     )
+ * }
+ * ```
+ * Will generate:
+ * ```css
+ * box-shadow: rgba(0, 0, 0, 0.15) 0px 1px 3px 1px;
+ * ```
+ *
+ * @see [BoxShadow.Inherit]
+ * @see [BoxShadow.Initial]
+ * @see [BoxShadow.None]
+ * @see [BoxShadow.Unset]
+ * @see [BoxShadow.of]
+ */
+fun StyleScope.boxShadow(shadow: BoxShadow) {
+    boxShadow(value = shadow.toString())
+}
 
-        if (spreadRadius != null) {
-            if (blurRadius == null) {
+/**
+ * Creates a box-shadow property with multiple shadow.
+ * The property accepts a list of shadows, created by
+ * using [BoxShadow.of], ordered from front to back.
+ *
+ * **The style is not created if no shadows are specified..**
+ *
+ * Usage:
+ * ```kotlin
+ * style {
+ *     boxShadow(
+ *         BoxShadow.of(
+ *             offsetX = 0.px,
+ *             offsetY = 1.px,
+ *             blurRadius = 3.px,
+ *             spreadRadius = 1.px,
+ *             color = Colors.Black.copyf(alpha = 0.15f),
+ *         ),
+ *         BoxShadow.of(
+ *             offsetX = 5.px,
+ *             offsetY = 8.px,
+ *             blurRadius = 10.px,
+ *             spreadRadius = (-1).px,
+ *             color = Colors.Black.copyf(alpha = 0.32f),
+ *         ),
+ *     )
+ * }
+ * ```
+ * Will generate:
+ * ```css
+ * box-shadow: rgba(0, 0, 0, 0.15) 0px 1px 3px 1px,
+ *             rgba(0, 0, 0, 0.318) 5px 8px 10px -1px;
+ * ```
+ */
+fun StyleScope.boxShadow(vararg shadows: BoxShadow.Shadow) {
+    if (shadows.isNotEmpty()) {
+        boxShadow(shadows.joinToString(transform = BoxShadow::toString))
+    }
+}
+
+/**
+ * The Kotlin representation of the CSS box-shadow.
+ */
+sealed class BoxShadow private constructor(private val value: String) : StylePropertyValue {
+    override fun toString(): String = value
+
+    private class Keyword(value: String): BoxShadow(value)
+
+    class Shadow internal constructor(
+        offsetX: CSSLengthNumericValue = 0.px,
+        offsetY: CSSLengthNumericValue = 0.px,
+        blurRadius: CSSLengthNumericValue? = null,
+        spreadRadius: CSSLengthNumericValue? = null,
+        color: CSSColorValue? = null,
+        inset: Boolean = false,
+    ) : BoxShadow(
+        value = buildString {
+            if (inset) {
+                append("inset")
                 append(' ')
-                append('0')
             }
+            append(offsetX)
             append(' ')
-            append(spreadRadius)
-        }
+            append(offsetY)
 
-        if (color != null) {
-            append(' ')
-            append(color)
-        }
-    })
+            if (blurRadius != null) {
+                append(' ')
+                append(blurRadius)
+            }
+
+            if (spreadRadius != null) {
+                if (blurRadius == null) {
+                    append(' ')
+                    append('0')
+                }
+                append(' ')
+                append(spreadRadius)
+            }
+
+            if (color != null) {
+                append(' ')
+                append(color)
+            }
+        },
+    )
+
+    companion object {
+        // Keyword
+        val None: BoxShadow = Keyword("none")
+        // Global Keywords
+        val Inherit: BoxShadow = Keyword("inherit")
+        val Initial: BoxShadow = Keyword("initial")
+        val Revert: BoxShadow = Keyword("revert")
+        val Unset: BoxShadow = Keyword("unset")
+
+        // Custom
+        /**
+         * Creates a shadow for the box-shadow property
+         *
+         * @property offsetX Specifies the **horizontal offset** of the shadow.
+         * A positive value draws a shadow that is offset to the right
+         * of the box, a negative length to the left.
+         * @property offsetY Specifies the **vertical offset** of the shadow.
+         * A positive value offsets the shadow down, a negative one up.
+         * @property blurRadius Specifies the **blur radius**. Negative values are
+         * invalid. If the blur value is zero, the shadow’s edge is sharp.
+         * Otherwise, the larger the value, the more the shadow’s edge is blurred.
+         * See [Shadow Blurring](https://www.w3.org/TR/css-backgrounds-3/#shadow-blur).
+         * @property spreadRadius Specifies the **spread distance**. Positive values
+         * cause the shadow to expand in all directions by the specified radius.
+         * Negative values cause the shadow to contract.
+         * See [Shadow Shape](https://www.w3.org/TR/css-backgrounds-3/#shadow-shape).
+         * @property color Specifies the color of the shadow. If the color is absent,
+         * it defaults to `currentColor` on CSS.
+         * @property inset If `true`, the `inset` keyword is inserted at the end and
+         * changes the drop shadow from an outer box-shadow (one that shadows the box
+         * onto the canvas, as if it were lifted above the canvas) to an inner
+         * box-shadow (one that shadows the canvas onto the box, as if the box were
+         * cut out of the canvas and shifted behind it).
+         */
+        fun of(
+            offsetX: CSSLengthNumericValue = 0.px,
+            offsetY: CSSLengthNumericValue = 0.px,
+            blurRadius: CSSLengthNumericValue? = null,
+            spreadRadius: CSSLengthNumericValue? = null,
+            color: CSSColorValue? = null,
+            inset: Boolean = false,
+        ): Shadow = Shadow(
+            offsetX = offsetX,
+            offsetY = offsetY,
+            blurRadius = blurRadius,
+            spreadRadius = spreadRadius,
+            color = color,
+            inset = inset,
+        )
+    }
 }

--- a/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/ui/modifiers/BoxModifiers.kt
+++ b/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/ui/modifiers/BoxModifiers.kt
@@ -9,6 +9,58 @@ fun Modifier.boxDecorationBreak(boxDecorationBreak: BoxDecorationBreak) = styleM
     boxDecorationBreak(boxDecorationBreak)
 }
 
+fun Modifier.boxSizing(boxSizing: BoxSizing) = styleModifier {
+    boxSizing(boxSizing)
+}
+
+/**
+ * Creates a single shadowed box-shadow to the desired element.
+ *
+ * Usage:
+ * ```kotlin
+ *  val ButtonBoxShadowVariant = ButtonStyle.addVariant {
+ *     base {
+ *          Modifier.boxShadow(
+ *              offsetX = 0.px,
+ *              offsetY = 1.px,
+ *              blurRadius = 3.px,
+ *              spreadRadius = 1.px,
+ *              color = Colors.Black.copyf(alpha = 0.15f),
+ *              inset = true,
+ *          )
+ *     }
+ * }
+ * ```
+ * The previous example generates the following css:
+ * ```css
+ * @layer component-variant {
+ *     .silk-button-box-shadow {
+ *         box-shadow: rgba(0, 0, 0, 0.15) 0px 1px 3px 1px inset;
+ *     }
+ * }
+ * ```
+ *
+ * @param offsetX Specifies the **horizontal offset** of the shadow.
+ * A positive value draws a shadow that is offset to the right
+ * of the box, a negative length to the left.
+ * @param offsetY Specifies the **vertical offset** of the shadow.
+ * A positive value offsets the shadow down, a negative one up.
+ * @param blurRadius Specifies the **blur radius**. Negative values are
+ * invalid. If the blur value is zero, the shadow’s edge is sharp.
+ * Otherwise, the larger the value, the more the shadow’s edge is blurred.
+ * See [Shadow Blurring](https://www.w3.org/TR/css-backgrounds-3/#shadow-blur).
+ * @param spreadRadius Specifies the **spread distance**. Positive values
+ * cause the shadow to expand in all directions by the specified radius.
+ * Negative values cause the shadow to contract.
+ * See [Shadow Shape](https://www.w3.org/TR/css-backgrounds-3/#shadow-shape).
+ * @param color Specifies the color of the shadow. If the color is absent,
+ * it defaults to `currentColor` on CSS.
+ * @param inset If `true`, the `inset` keyword is inserted at the end and
+ * changes the drop shadow from an outer box-shadow (one that shadows the box
+ * onto the canvas, as if it were lifted above the canvas) to an inner
+ * box-shadow (one that shadows the canvas onto the box, as if the box were
+ * cut out of the canvas and shifted behind it).
+ */
 fun Modifier.boxShadow(
     offsetX: CSSLengthNumericValue = 0.px,
     offsetY: CSSLengthNumericValue = 0.px,
@@ -16,10 +68,116 @@ fun Modifier.boxShadow(
     spreadRadius: CSSLengthNumericValue? = null,
     color: CSSColorValue? = null,
     inset: Boolean = false,
-) = styleModifier {
-    this.boxShadow(offsetX, offsetY, blurRadius, spreadRadius, color, inset)
+) = boxShadow(BoxShadow.of(offsetX, offsetY, blurRadius, spreadRadius, color, inset))
+
+/**
+ * The box-shadow property attaches one or more drop shadows to the box.
+ * The property accepts either the [BoxShadow.None] value, which indicates no shadows,
+ * or a list of shadows, created by using [BoxShadow.of], ordered front to back.
+ *
+ * Usage:
+ * ```kotlin
+ * val ButtonBoxShadowVariant = ButtonStyle.addVariant {
+ *     base {
+ *          Modifier.boxShadow(
+ *              BoxShadow.of(
+ *                  offsetX = 0.px,
+ *                  offsetY = 1.px,
+ *                  blurRadius = 3.px,
+ *                  spreadRadius = 1.px,
+ *                  color = Colors.Black.copyf(alpha = 0.15f),
+ *              ),
+ *              BoxShadow.of(
+ *                  offsetX = 0.px,
+ *                  offsetY = 1.px,
+ *                  blurRadius = 2.px,
+ *                  spreadRadius = 0.px,
+ *                  color = Colors.Black.copyf(alpha = 0.3f),
+ *              ),
+ *          )
+ *     }
+ * }
+ * ```
+ * The previous example generates the following css:
+ * ```css
+ * @layer component-variant {
+ *     .silk-button-box-shadow {
+ *         box-shadow: box-shadow: rgba(0, 0, 0, 0.15) 0px 1px 3px 1px,
+ *                     rgba(0, 0, 0, 0.298) 0px 1px 2px 0px;
+ *     }
+ * }
+ * ```
+ */
+fun Modifier.boxShadow(vararg shadows: BoxShadow.Shadow): Modifier = styleModifier {
+    boxShadow(shadows = shadows)
 }
 
-fun Modifier.boxSizing(boxSizing: BoxSizing) = styleModifier {
-    boxSizing(boxSizing)
+/**
+ * Creates a box-shadow property with a single shadow.
+ * The property accepts either the [BoxShadow.None] value, the
+ * default global keywords, which indicates no shadows, or a
+ * list of shadows, created by using [BoxShadow.of], ordered
+ * front to back.
+ *
+ * Usages:
+ * ```kotlin
+ * val ButtonBoxShadowVariant = ButtonStyle.addVariant {
+ *     base {
+ *         Modifier.boxShadow(BoxShadow.None)
+ *     }
+ * }
+ * ```
+ * Will generate:
+ * ```css
+ * @layer component-variant {
+ *     .silk-button-box-shadow {
+ *         box-shadow: none
+ *     }
+ * }
+ * ```
+ *
+ * ```kotlin
+ * val ButtonBoxShadowVariant = ButtonStyle.addVariant {
+ *     base {
+ *         Modifier.boxShadow(BoxShadow.Unset)
+ *     }
+ * }
+ * ```
+ * Will generate:
+ * ```css
+ * @layer component-variant {
+ *     .silk-button-box-shadow {
+ *         box-shadow: unset
+ *     }
+ * }
+ * ```
+ *
+ * ```kotlin
+ * val ButtonBoxShadowVariant = ButtonStyle.addVariant {
+ *     base {
+ *         Modifier.boxShadow(
+ *             BoxShadow.of(
+ *                 offsetX = 0.px,
+ *                 offsetY = 1.px,
+ *                 blurRadius = 3.px,
+ *                 spreadRadius = 1.px,
+ *                 color = Colors.Black.copyf(alpha = 0.15f),
+ *             ),
+ *         )
+ *     }
+ * }
+ * ```
+ * Will generate:
+ * ```css
+ * box-shadow: rgba(0, 0, 0, 0.15) 0px 1px 3px 1px;
+ * ```
+ *
+ * @see [BoxShadow.Inherit]
+ * @see [BoxShadow.Initial]
+ * @see [BoxShadow.None]
+ * @see [BoxShadow.Unset]
+ * @see [BoxShadow.of]
+ */
+fun Modifier.boxShadow(shadow: BoxShadow): Modifier = styleModifier {
+    boxShadow(shadow = shadow)
 }


### PR DESCRIPTION
Currently, the BoxShadow Modifier API only supports a single shadow. This PR enables the API to receive multiple shadows or `none`, in case the user wants to remove a shadow in a variant style.