### PR TITLE
Improve accesibility via adding content to the label

### DIFF
--- a/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/forms/Switch.kt
+++ b/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/forms/Switch.kt
@@ -28,6 +28,7 @@ import com.varabyte.kobweb.silk.theme.colors.palette.toPalette
 import org.jetbrains.compose.web.attributes.InputType
 import org.jetbrains.compose.web.css.*
 import org.jetbrains.compose.web.dom.Label
+import org.jetbrains.compose.web.dom.Text
 import org.w3c.dom.HTMLElement
 
 object SwitchVars {
@@ -166,11 +167,13 @@ fun Switch(
     // Use a label so it intercepts clicks and passes them to the inner Input
     Label(
         attrs = SwitchStyle.toModifier(variant)
+            .fontSize(0.px)
             .then(size.toModifier())
             .then(shape.toModifier())
             .then(modifier)
             .toAttrs()
     ) {
+        Text("Switch")
         registerRefScope(ref)
         // We base Switch on a checkbox input for a11y + built-in input/keyboard support, but hide the checkbox itself
         // and render the switch separately. We do however allow it to be focused, which combined with the outer label

--- a/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/forms/Switch.kt
+++ b/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/forms/Switch.kt
@@ -28,7 +28,6 @@ import com.varabyte.kobweb.silk.theme.colors.palette.toPalette
 import org.jetbrains.compose.web.attributes.InputType
 import org.jetbrains.compose.web.css.*
 import org.jetbrains.compose.web.dom.Label
-import org.jetbrains.compose.web.dom.Text
 import org.w3c.dom.HTMLElement
 
 object SwitchVars {
@@ -167,13 +166,11 @@ fun Switch(
     // Use a label so it intercepts clicks and passes them to the inner Input
     Label(
         attrs = SwitchStyle.toModifier(variant)
-            .fontSize(0.px)
             .then(size.toModifier())
             .then(shape.toModifier())
             .then(modifier)
             .toAttrs()
     ) {
-        Text("Switch")
         registerRefScope(ref)
         // We base Switch on a checkbox input for a11y + built-in input/keyboard support, but hide the checkbox itself
         // and render the switch separately. We do however allow it to be focused, which combined with the outer label
@@ -184,6 +181,8 @@ fun Switch(
             onValueChanged = { onCheckedChange(!checked) },
             variant = SwitchInputVariant,
             enabled = enabled,
+            modifier = Modifier
+                .ariaLabel("switch")
         )
         Box(
             SwitchTrackStyle.toModifier()

--- a/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/forms/Switch.kt
+++ b/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/forms/Switch.kt
@@ -182,7 +182,7 @@ fun Switch(
             variant = SwitchInputVariant,
             enabled = enabled,
             modifier = Modifier
-                .ariaLabel("switch")
+                .ariaLabel("switch"),
         )
         Box(
             SwitchTrackStyle.toModifier()


### PR DESCRIPTION
This pull request addresses an accessibility issue identified using the Lighthouse tool. The problem occurs due to the Switch Component lacking a proper label that describes the input used as a switch.

To resolve this, I added the modifier `arialLabel` to the Input Component. This solution I get it from here [aria-label accesibility](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label)

You can see similar problems discussed in the following links:

[Deque University: Accessibility Rule - Ensure every form element has a label](https://dequeuniversity.com/rules/axe/4.8/label)


