### PR TITLE
Add support for `Arrangement.spacedBy`

### DIFF
--- a/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/foundation/layout/Arrangement.kt
+++ b/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/foundation/layout/Arrangement.kt
@@ -243,8 +243,8 @@ object Arrangement {
  * @property spacing The spacing value used in the arrangement.
  */
 internal sealed class SpacedAligned(
-    open val spacing: CSSSizeValue<out CSSUnitLength>,
-) {
+    override val spacing: CSSSizeValue<out CSSUnitLength>,
+) : Arrangement.HorizontalOrVertical {
     /**
      * The CSS classes applied to the arrangement.
      */
@@ -258,7 +258,7 @@ internal sealed class SpacedAligned(
  */
 internal data class SpacedAlignedHorizontalOrVertical(
     override val spacing: CSSSizeValue<out CSSUnitLength>,
-) : SpacedAligned(spacing), Arrangement.HorizontalOrVertical {
+) : SpacedAligned(spacing) {
     // Custom classes for default alignment applied for spacing and alignment
     override val classes = arrayOf(KOBWEB_ARRANGE_SPACED_BY, KOBWEB_ARRANGE_START)
 }

--- a/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/foundation/layout/Arrangement.kt
+++ b/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/foundation/layout/Arrangement.kt
@@ -248,7 +248,7 @@ internal sealed class SpacedAligned(
     /**
      * The CSS classes applied to the arrangement.
      */
-    abstract val classes: Array<String>
+    abstract val classNames: Array<String>
 }
 
 /**
@@ -260,7 +260,7 @@ internal data class SpacedAlignedHorizontalOrVertical(
     override val spacing: CSSSizeValue<out CSSUnitLength>,
 ) : SpacedAligned(spacing) {
     // Custom classes for default alignment applied for spacing and alignment
-    override val classes = arrayOf(KOBWEB_ARRANGE_SPACED_BY, KOBWEB_ARRANGE_START)
+    override val classNames = arrayOf(KOBWEB_ARRANGE_SPACED_BY, KOBWEB_ARRANGE_START)
 }
 
 /**
@@ -274,7 +274,7 @@ internal data class SpacedVerticalAligned(
     val alignment: Alignment.Vertical,
 ) : SpacedAligned(spacing), Arrangement.Vertical {
     // Custom classes for vertical alignment based on the alignment type
-    override val classes: Array<String> = arrayOf(
+    override val classNames: Array<String> = arrayOf(
         KOBWEB_ARRANGE_SPACED_BY,
         when (alignment) {
             Alignment.Bottom -> KOBWEB_ARRANGE_BOTTOM
@@ -296,7 +296,7 @@ internal data class SpacedHorizontalAligned(
     val alignment: Alignment.Horizontal,
 ) : SpacedAligned(spacing), Arrangement.Horizontal {
     // Custom classes for horizontal alignment based on the alignment type
-    override val classes: Array<String> = arrayOf(
+    override val classNames: Array<String> = arrayOf(
         KOBWEB_ARRANGE_SPACED_BY,
         when (alignment) {
             Alignment.Start -> KOBWEB_ARRANGE_START

--- a/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/foundation/layout/Arrangement.kt
+++ b/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/foundation/layout/Arrangement.kt
@@ -1,18 +1,74 @@
 package com.varabyte.kobweb.compose.foundation.layout
 
-object Arrangement {
-    sealed interface Horizontal
-    sealed interface Vertical
-    sealed interface HorizontalOrVertical : Horizontal, Vertical
+import com.varabyte.kobweb.compose.css.*
+import com.varabyte.kobweb.compose.style.KOBWEB_ARRANGE_BOTTOM
+import com.varabyte.kobweb.compose.style.KOBWEB_ARRANGE_CENTER
+import com.varabyte.kobweb.compose.style.KOBWEB_ARRANGE_END
+import com.varabyte.kobweb.compose.style.KOBWEB_ARRANGE_FROM_STYLE
+import com.varabyte.kobweb.compose.style.KOBWEB_ARRANGE_SPACED_BY
+import com.varabyte.kobweb.compose.style.KOBWEB_ARRANGE_START
+import com.varabyte.kobweb.compose.style.KOBWEB_ARRANGE_TOP
+import com.varabyte.kobweb.compose.ui.Alignment
+import org.jetbrains.compose.web.css.*
 
-    object End : Horizontal
-    object Start : Horizontal
-    object Top : Vertical
-    object Bottom : Vertical
-    object Center : HorizontalOrVertical
-    object SpaceEvenly : HorizontalOrVertical
-    object SpaceBetween : HorizontalOrVertical
-    object SpaceAround : HorizontalOrVertical
+/**
+ * Used to specify the arrangement of the layout's children in layouts like
+ * [Row] or [Column] in their main axis direction (horizontal and vertical,
+ * respectively).
+ */
+object Arrangement {
+    /**
+     * Specifies the horizontal arrangement of the children. Mostly used on [Row].
+     */
+    sealed interface Horizontal {
+        /**
+         * Spacing added between any two adjacent children.
+         * defaults to `0.px`
+         */
+        val spacing: CSSLengthNumericValue get() = 0.px
+    }
+
+    /**
+     * Specifies the vertical arrangement of the children. Mostly used on [Column].
+     */
+    sealed interface Vertical {
+        /**
+         * Spacing added between any two adjacent children.
+         * defaults to `0.px`
+         */
+        val spacing: CSSLengthNumericValue get() = 0.px
+    }
+
+    /**
+     * Specifies either horizontal or vertical arrangement, depending on the layout
+     * main axis of the container layout.
+     *
+     * E.g.: [Row] will take a horizontal arrangement and [Column] takes vertical
+     * arrangement.
+     */
+    sealed interface HorizontalOrVertical : Horizontal, Vertical {
+        /**
+         * Spacing added between any two adjacent children.
+         * defaults to `0.px`
+         */
+        override val spacing: CSSLengthNumericValue get() = 0.px
+    }
+
+    data object End : Horizontal
+
+    data object Start : Horizontal
+
+    data object Top : Vertical
+
+    data object Bottom : Vertical
+
+    data object Center : HorizontalOrVertical
+
+    data object SpaceEvenly : HorizontalOrVertical
+
+    data object SpaceBetween : HorizontalOrVertical
+
+    data object SpaceAround : HorizontalOrVertical
 
     /**
      * A special value indicating that this element's arrangement will be controlled manually using CSS styles.
@@ -35,5 +91,218 @@ object Arrangement {
      * underlying element (flexbox for rows and columns). It will be up to you to use the right `justify` / `align`
      * modifier methods to get the behavior you want.
      */
-    object FromStyle : HorizontalOrVertical
+    data object FromStyle : HorizontalOrVertical
+
+    /**
+     * Arranges the children of the container with a fixed [space] for both horizontal and vertical orientations.
+     * This function is marked as stable, ensuring that its result can be safely used in recompositions.
+     *
+     * **Important: As we use CSS gap to apply the spacing, negative spaces will be ignored.**
+     *
+     * **Usage**:
+     * ```kotlin
+     * Column(
+     *     verticalArrangement = Arrangement.spacedBy(space = 10.px),
+     * ) {
+     *     SpanText("1")
+     *     SpanText("2")
+     *     SpanText("3")
+     * }
+     * ```
+     * The above code will generate the following html:
+     * ```html
+     * <div class="kobweb-col kobweb-arrange-spaced-by kobweb-arrange-start kobweb-align-start" style="--kobweb-arrange-spaced-by-value: 10px;">
+     *     <span class="silk-span-text">1</span>
+     *     <span class="silk-span-text">2</span>
+     *     <span class="silk-span-text">3</span>
+     * </div>
+     * ```
+     *
+     * or
+     *
+     * ```kotlin
+     * Row(
+     *     horizontalArrangement = Arrangement.spacedBy(space = 10.px),
+     * ) {
+     *     SpanText("1")
+     *     SpanText("2")
+     *     SpanText("3")
+     * }
+     * ```
+     * The above code will generate the following html:
+     * ```html
+     * <div class="kobweb-row kobweb-arrange-spaced-by kobweb-arrange-start kobweb-align-top" style="--kobweb-arrange-spaced-by-value: 10px;">
+     *     <span class="silk-span-text">1</span>
+     *     <span class="silk-span-text">2</span>
+     *     <span class="silk-span-text">3</span>
+     * </div>
+     * ```
+     *
+     * @param space The spacing value between elements, defined using CSS size units.
+     * Expects values between [[0,∞]].
+     */
+    fun spacedBy(space: CSSSizeValue<out CSSUnitLength>): HorizontalOrVertical =
+        SpacedAlignedHorizontalOrVertical(space)
+
+    /**
+     * Arranges the children of the container with a fixed [space] for vertical orientations.
+     * An [alignment] can be specified to align the spaced children vertically inside the parent,
+     * in case there is height remaining.
+     *
+     * This function is marked as stable, ensuring that its result can be safely used in recompositions.
+     *
+     * **Important: As we use CSS gap to apply the spacing, negative spaces will be ignored.**
+     *
+     * **Usage**:
+     * ```kotlin
+     * Column(
+     *     verticalArrangement = Arrangement.spacedBy(space = 10.px, alignment = Alignment.CenterVertically)),
+     * ) {
+     *     SpanText("1")
+     *     SpanText("2")
+     *     SpanText("3")
+     * }
+     * ```
+     * The above code will generate the following html:
+     * ```html
+     * <div class="kobweb-col kobweb-arrange-spaced-by kobweb-arrange-center kobweb-align-start" style="--kobweb-arrange-spaced-by-value: 10px;">
+     *     <span class="silk-span-text">1</span>
+     *     <span class="silk-span-text">2</span>
+     *     <span class="silk-span-text">3</span>
+     * </div>
+     * ```
+     *
+     * **Note**:
+     * When using:
+     *  * [Alignment.CenterVertically], the `kobweb-arrange-center` class is placed together with
+     *  `kobweb-arrange-spaced-by`
+     *  * [Alignment.Top], the `kobweb-arrange-top` class is placed together with
+     *  `kobweb-arrange-spaced-by`
+     *  * [Alignment.Bottom], the `kobweb-arrange-bottom` class is placed together with
+     *  `kobweb-arrange-spaced-by`
+     *
+     * @param space The spacing value between elements, defined using CSS size units.
+     * Expects value between [[0,∞]].
+     * @see Alignment.CenterVertically
+     * @see Alignment.Top
+     * @see Alignment.Bottom
+     */
+    fun spacedBy(space: CSSSizeValue<out CSSUnitLength>, alignment: Alignment.Vertical): Vertical =
+        SpacedVerticalAligned(space, alignment)
+
+    /**
+     * Arranges the children of the container with a fixed [space] for vertical orientations.
+     * An [alignment] can be specified to align the spaced children vertically inside the parent,
+     * in case there is width remaining.
+     *
+     * This function is marked as stable, ensuring that its result can be safely used in recompositions.
+     *
+     * **Important: As we use CSS gap to apply the spacing, negative spaces will be ignored.**
+     *
+     * **Usage**:
+     * ```kotlin
+     * Row(
+     *     horizontalArrangement = Arrangement.spacedBy(space = 10.px, alignment = Alignment.CenterHorizontally),
+     * ) {
+     *     SpanText("1")
+     *     SpanText("2")
+     *     SpanText("3")
+     * }
+     * ```
+     * The above code will generate the following html:
+     * ```html
+     * <div class="kobweb-row kobweb-arrange-spaced-by kobweb-arrange-center kobweb-align-top" style="--kobweb-arrange-spaced-by-value: 10px;">
+     *     <span class="silk-span-text">1</span>
+     *     <span class="silk-span-text">2</span>
+     *     <span class="silk-span-text">3</span>
+     * </div>
+     * ```
+     *
+     * **Note**:
+     * When using:
+     *  * [Alignment.CenterHorizontally], the `kobweb-arrange-center` class is placed together with
+     *  `kobweb-arrange-spaced-by`
+     *  * [Alignment.Start], the `kobweb-arrange-start` class is placed together with
+     *  `kobweb-arrange-spaced-by`
+     *  * [Alignment.End], the `kobweb-arrange-end` class is placed together with
+     *  `kobweb-arrange-spaced-by`
+     *
+     * @param space The spacing value between elements, defined using CSS size units.
+     * Expects value between [[0,∞]].
+     * @see Alignment.CenterHorizontally
+     * @see Alignment.Start
+     * @see Alignment.End
+     */
+    fun spacedBy(space: CSSSizeValue<out CSSUnitLength>, alignment: Alignment.Horizontal): Horizontal =
+        SpacedHorizontalAligned(space, alignment)
+}
+
+/**
+ * Sealed class representing a spaced an [Arrangement] with a given spacing.
+ *
+ * @property spacing The spacing value used in the arrangement.
+ */
+internal sealed class SpacedAligned(
+    open val spacing: CSSSizeValue<out CSSUnitLength>,
+) {
+    /**
+     * The CSS classes applied to the arrangement.
+     */
+    abstract val classes: Array<String>
+}
+
+/**
+ * Representation either horizontal or vertical spaced and aligned arrangement.
+ *
+ * @property spacing The spacing value used in the arrangement.
+ */
+internal data class SpacedAlignedHorizontalOrVertical(
+    override val spacing: CSSSizeValue<out CSSUnitLength>,
+) : SpacedAligned(spacing), Arrangement.HorizontalOrVertical {
+    // Custom classes for default alignment applied for spacing and alignment
+    override val classes = arrayOf(KOBWEB_ARRANGE_SPACED_BY, KOBWEB_ARRANGE_START)
+}
+
+/**
+ * Representation of a vertically spaced and aligned arrangement.
+ *
+ * @property spacing The spacing value used in the arrangement.
+ * @property alignment The vertical alignment used in the arrangement.
+ */
+internal data class SpacedVerticalAligned(
+    override val spacing: CSSSizeValue<out CSSUnitLength>,
+    val alignment: Alignment.Vertical,
+) : SpacedAligned(spacing), Arrangement.Vertical {
+    // Custom classes for vertical alignment based on the alignment type
+    override val classes: Array<String> = arrayOf(
+        KOBWEB_ARRANGE_SPACED_BY,
+        when (alignment) {
+            Alignment.Bottom -> KOBWEB_ARRANGE_BOTTOM
+            Alignment.CenterVertically -> KOBWEB_ARRANGE_CENTER
+            Alignment.FromStyle -> KOBWEB_ARRANGE_FROM_STYLE
+            Alignment.Top -> KOBWEB_ARRANGE_TOP
+        },
+    )
+}
+
+/**
+ * Representation of a horizontally spaced and aligned arrangement.
+ *
+ * @property spacing The spacing value used in the arrangement.
+ * @property alignment The horizontal alignment used in the arrangement.
+ */
+internal data class SpacedHorizontalAligned(
+    override val spacing: CSSSizeValue<out CSSUnitLength>,
+    val alignment: Alignment.Horizontal,
+) : SpacedAligned(spacing), Arrangement.Horizontal {
+    // Custom classes for horizontal alignment based on the alignment type
+    override val classes: Array<String> = arrayOf(
+        KOBWEB_ARRANGE_SPACED_BY,
+        when (alignment) {
+            Alignment.Start -> KOBWEB_ARRANGE_START
+            Alignment.CenterHorizontally -> KOBWEB_ARRANGE_CENTER
+            Alignment.FromStyle -> KOBWEB_ARRANGE_FROM_STYLE
+            Alignment.End -> KOBWEB_ARRANGE_END
+        },
+    )
 }

--- a/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/foundation/layout/Column.kt
+++ b/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/foundation/layout/Column.kt
@@ -3,11 +3,14 @@ package com.varabyte.kobweb.compose.foundation.layout
 import androidx.compose.runtime.*
 import com.varabyte.kobweb.compose.dom.ElementRefScope
 import com.varabyte.kobweb.compose.dom.registerRefScope
+import com.varabyte.kobweb.compose.style.ArrangeSpacedByValue
 import com.varabyte.kobweb.compose.style.toClassName
+import com.varabyte.kobweb.compose.style.toClasses
 import com.varabyte.kobweb.compose.ui.Alignment
 import com.varabyte.kobweb.compose.ui.Modifier
 import com.varabyte.kobweb.compose.ui.attrsModifier
 import com.varabyte.kobweb.compose.ui.modifiers.*
+import com.varabyte.kobweb.compose.ui.thenIf
 import com.varabyte.kobweb.compose.ui.toAttrs
 import org.jetbrains.compose.web.dom.Div
 import org.w3c.dom.HTMLElement
@@ -37,7 +40,7 @@ object ColumnDefaults {
 fun Modifier.columnClasses(
     verticalArrangement: Arrangement.Vertical = ColumnDefaults.VerticalArrangement,
     horizontalAlignment: Alignment.Horizontal = ColumnDefaults.HorizontalAlignment,
-) = this.classNames("kobweb-col", verticalArrangement.toClassName(), horizontalAlignment.toClassName())
+) = this.classNames("kobweb-col", *verticalArrangement.toClasses(), horizontalAlignment.toClassName())
 
 @Composable
 fun Column(
@@ -47,7 +50,16 @@ fun Column(
     ref: ElementRefScope<HTMLElement>? = null,
     content: @Composable ColumnScope.() -> Unit
 ) {
-    Div(modifier.columnClasses(verticalArrangement, horizontalAlignment).toAttrs()) {
+    Div(
+        attrs = modifier
+            .columnClasses(verticalArrangement, horizontalAlignment)
+            .thenIf(
+                verticalArrangement is SpacedAligned,
+            ) {
+                Modifier.setVariable(ArrangeSpacedByValue, verticalArrangement.spacing)
+            }
+            .toAttrs(),
+    ) {
         registerRefScope(ref)
         ColumnScopeInstance.content()
     }

--- a/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/foundation/layout/Column.kt
+++ b/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/foundation/layout/Column.kt
@@ -5,7 +5,7 @@ import com.varabyte.kobweb.compose.dom.ElementRefScope
 import com.varabyte.kobweb.compose.dom.registerRefScope
 import com.varabyte.kobweb.compose.style.ArrangeSpacedByValue
 import com.varabyte.kobweb.compose.style.toClassName
-import com.varabyte.kobweb.compose.style.toClasses
+import com.varabyte.kobweb.compose.style.toClassNames
 import com.varabyte.kobweb.compose.ui.Alignment
 import com.varabyte.kobweb.compose.ui.Modifier
 import com.varabyte.kobweb.compose.ui.attrsModifier
@@ -40,7 +40,7 @@ object ColumnDefaults {
 fun Modifier.columnClasses(
     verticalArrangement: Arrangement.Vertical = ColumnDefaults.VerticalArrangement,
     horizontalAlignment: Alignment.Horizontal = ColumnDefaults.HorizontalAlignment,
-) = this.classNames("kobweb-col", *verticalArrangement.toClasses(), horizontalAlignment.toClassName())
+) = this.classNames("kobweb-col", *verticalArrangement.toClassNames(), horizontalAlignment.toClassName())
 
 @Composable
 fun Column(

--- a/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/foundation/layout/Row.kt
+++ b/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/foundation/layout/Row.kt
@@ -3,11 +3,14 @@ package com.varabyte.kobweb.compose.foundation.layout
 import androidx.compose.runtime.*
 import com.varabyte.kobweb.compose.dom.ElementRefScope
 import com.varabyte.kobweb.compose.dom.registerRefScope
+import com.varabyte.kobweb.compose.style.ArrangeSpacedByValue
 import com.varabyte.kobweb.compose.style.toClassName
+import com.varabyte.kobweb.compose.style.toClasses
 import com.varabyte.kobweb.compose.ui.Alignment
 import com.varabyte.kobweb.compose.ui.Modifier
 import com.varabyte.kobweb.compose.ui.attrsModifier
 import com.varabyte.kobweb.compose.ui.modifiers.*
+import com.varabyte.kobweb.compose.ui.thenIf
 import com.varabyte.kobweb.compose.ui.toAttrs
 import org.jetbrains.compose.web.dom.Div
 import org.w3c.dom.HTMLElement
@@ -38,7 +41,7 @@ fun Modifier.rowClasses(
     horizontalArrangement: Arrangement.Horizontal = RowDefaults.HorizontalArrangement,
     verticalAlignment: Alignment.Vertical = RowDefaults.VerticalAlignment,
 ) = this
-    .classNames("kobweb-row", horizontalArrangement.toClassName(), verticalAlignment.toClassName())
+    .classNames("kobweb-row", *horizontalArrangement.toClasses(), verticalAlignment.toClassName())
 
 @Composable
 fun Row(
@@ -48,7 +51,16 @@ fun Row(
     ref: ElementRefScope<HTMLElement>? = null,
     content: @Composable RowScope.() -> Unit
 ) {
-    Div(modifier.rowClasses(horizontalArrangement, verticalAlignment).toAttrs()) {
+    Div(
+        attrs = modifier
+            .rowClasses(horizontalArrangement, verticalAlignment)
+            .thenIf(
+                horizontalArrangement is SpacedAligned,
+            ) {
+                Modifier.setVariable(ArrangeSpacedByValue, horizontalArrangement.spacing)
+            }
+            .toAttrs(),
+    ) {
         registerRefScope(ref)
         RowScopeInstance.content()
     }

--- a/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/foundation/layout/Row.kt
+++ b/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/foundation/layout/Row.kt
@@ -5,7 +5,7 @@ import com.varabyte.kobweb.compose.dom.ElementRefScope
 import com.varabyte.kobweb.compose.dom.registerRefScope
 import com.varabyte.kobweb.compose.style.ArrangeSpacedByValue
 import com.varabyte.kobweb.compose.style.toClassName
-import com.varabyte.kobweb.compose.style.toClasses
+import com.varabyte.kobweb.compose.style.toClassNames
 import com.varabyte.kobweb.compose.ui.Alignment
 import com.varabyte.kobweb.compose.ui.Modifier
 import com.varabyte.kobweb.compose.ui.attrsModifier
@@ -41,7 +41,7 @@ fun Modifier.rowClasses(
     horizontalArrangement: Arrangement.Horizontal = RowDefaults.HorizontalArrangement,
     verticalAlignment: Alignment.Vertical = RowDefaults.VerticalAlignment,
 ) = this
-    .classNames("kobweb-row", *horizontalArrangement.toClasses(), verticalAlignment.toClassName())
+    .classNames("kobweb-row", *horizontalArrangement.toClassNames(), verticalAlignment.toClassName())
 
 @Composable
 fun Row(

--- a/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/style/Arrangement.kt
+++ b/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/style/Arrangement.kt
@@ -1,23 +1,50 @@
 package com.varabyte.kobweb.compose.style
 
+import com.varabyte.kobweb.compose.css.*
 import com.varabyte.kobweb.compose.foundation.layout.Arrangement
+import com.varabyte.kobweb.compose.foundation.layout.SpacedAligned
+import com.varabyte.kobweb.compose.foundation.layout.SpacedHorizontalAligned
+import com.varabyte.kobweb.compose.foundation.layout.SpacedVerticalAligned
+import org.jetbrains.compose.web.css.*
 
-fun Arrangement.Horizontal.toClassName() = when (this) {
-    Arrangement.End -> "kobweb-arrange-end"
-    Arrangement.Start -> "kobweb-arrange-start"
-    is Arrangement.HorizontalOrVertical -> this.toClassName()
+internal const val KOBWEB_ARRANGE_BOTTOM = "kobweb-arrange-bottom"
+internal const val KOBWEB_ARRANGE_CENTER = "kobweb-arrange-center"
+internal const val KOBWEB_ARRANGE_END = "kobweb-arrange-end"
+internal const val KOBWEB_ARRANGE_FROM_STYLE = "kobweb-arrange-from-style"
+internal const val KOBWEB_ARRANGE_SPACED_BY = "kobweb-arrange-spaced-by"
+internal const val KOBWEB_ARRANGE_SPACE_AROUND = "kobweb-arrange-space-around"
+internal const val KOBWEB_ARRANGE_SPACE_BETWEEN = "kobweb-arrange-space-between"
+internal const val KOBWEB_ARRANGE_SPACE_EVENLY = "kobweb-arrange-space-evenly"
+internal const val KOBWEB_ARRANGE_START = "kobweb-arrange-start"
+internal const val KOBWEB_ARRANGE_TOP = "kobweb-arrange-top"
+
+internal val ArrangeSpacedByValue by StyleVariable<CSSNumeric>(prefix = "kobweb")
+
+internal fun KobwebComposeStyleSheet.initArrangeSpacedByStyle() {
+    ".kobweb-row.${KOBWEB_ARRANGE_SPACED_BY}" { gap(ArrangeSpacedByValue.value()) }
+    ".kobweb-col.${KOBWEB_ARRANGE_SPACED_BY}" { gap(ArrangeSpacedByValue.value()) }
 }
 
-fun Arrangement.Vertical.toClassName() = when (this) {
-    Arrangement.Top -> "kobweb-arrange-top"
-    Arrangement.Bottom -> "kobweb-arrange-bottom"
-    is Arrangement.HorizontalOrVertical -> this.toClassName()
+fun Arrangement.Horizontal.toClasses() = when (this) {
+    Arrangement.End -> arrayOf(KOBWEB_ARRANGE_END)
+    Arrangement.Start -> arrayOf(KOBWEB_ARRANGE_START)
+    is Arrangement.HorizontalOrVertical -> this.toClasses()
+    is SpacedHorizontalAligned -> classes
 }
 
-fun Arrangement.HorizontalOrVertical.toClassName() = when (this) {
-    Arrangement.Center -> "kobweb-arrange-center"
-    Arrangement.SpaceAround -> "kobweb-arrange-space-around"
-    Arrangement.SpaceBetween -> "kobweb-arrange-space-between"
-    Arrangement.SpaceEvenly -> "kobweb-arrange-space-evenly"
-    Arrangement.FromStyle -> "kobweb-arrange-from-style"
+fun Arrangement.Vertical.toClasses() = when (this) {
+    Arrangement.Top -> arrayOf(KOBWEB_ARRANGE_TOP)
+    Arrangement.Bottom -> arrayOf(KOBWEB_ARRANGE_BOTTOM)
+    is Arrangement.HorizontalOrVertical -> toClasses()
+    is SpacedAligned -> classes
+    is SpacedVerticalAligned -> classes
+}
+
+fun Arrangement.HorizontalOrVertical.toClasses() = when (this) {
+    Arrangement.Center -> arrayOf(KOBWEB_ARRANGE_CENTER)
+    Arrangement.SpaceAround -> arrayOf(KOBWEB_ARRANGE_SPACE_AROUND)
+    Arrangement.SpaceBetween -> arrayOf(KOBWEB_ARRANGE_SPACE_BETWEEN)
+    Arrangement.SpaceEvenly -> arrayOf(KOBWEB_ARRANGE_SPACE_EVENLY)
+    Arrangement.FromStyle -> arrayOf(KOBWEB_ARRANGE_FROM_STYLE)
+    is SpacedAligned -> classes
 }

--- a/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/style/Arrangement.kt
+++ b/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/style/Arrangement.kt
@@ -3,8 +3,6 @@ package com.varabyte.kobweb.compose.style
 import com.varabyte.kobweb.compose.css.*
 import com.varabyte.kobweb.compose.foundation.layout.Arrangement
 import com.varabyte.kobweb.compose.foundation.layout.SpacedAligned
-import com.varabyte.kobweb.compose.foundation.layout.SpacedHorizontalAligned
-import com.varabyte.kobweb.compose.foundation.layout.SpacedVerticalAligned
 import org.jetbrains.compose.web.css.*
 
 internal const val KOBWEB_ARRANGE_BOTTOM = "kobweb-arrange-bottom"
@@ -25,23 +23,23 @@ internal fun KobwebComposeStyleSheet.initArrangeSpacedByStyle() {
     ".kobweb-col.${KOBWEB_ARRANGE_SPACED_BY}" { gap(ArrangeSpacedByValue.value()) }
 }
 
-fun Arrangement.Horizontal.toClasses() = when (this) {
+fun Arrangement.Horizontal.toClassNames() = when (this) {
     Arrangement.End -> arrayOf(KOBWEB_ARRANGE_END)
     Arrangement.Start -> arrayOf(KOBWEB_ARRANGE_START)
-    is Arrangement.HorizontalOrVertical -> this.toClasses()
+    is Arrangement.HorizontalOrVertical -> this.toClassNames()
 }
 
-fun Arrangement.Vertical.toClasses() = when (this) {
+fun Arrangement.Vertical.toClassNames() = when (this) {
     Arrangement.Top -> arrayOf(KOBWEB_ARRANGE_TOP)
     Arrangement.Bottom -> arrayOf(KOBWEB_ARRANGE_BOTTOM)
-    is Arrangement.HorizontalOrVertical -> toClasses()
+    is Arrangement.HorizontalOrVertical -> toClassNames()
 }
 
-fun Arrangement.HorizontalOrVertical.toClasses() = when (this) {
+fun Arrangement.HorizontalOrVertical.toClassNames() = when (this) {
     Arrangement.Center -> arrayOf(KOBWEB_ARRANGE_CENTER)
     Arrangement.SpaceAround -> arrayOf(KOBWEB_ARRANGE_SPACE_AROUND)
     Arrangement.SpaceBetween -> arrayOf(KOBWEB_ARRANGE_SPACE_BETWEEN)
     Arrangement.SpaceEvenly -> arrayOf(KOBWEB_ARRANGE_SPACE_EVENLY)
     Arrangement.FromStyle -> arrayOf(KOBWEB_ARRANGE_FROM_STYLE)
-    is SpacedAligned -> classes
+    is SpacedAligned -> classNames
 }

--- a/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/style/Arrangement.kt
+++ b/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/style/Arrangement.kt
@@ -29,15 +29,12 @@ fun Arrangement.Horizontal.toClasses() = when (this) {
     Arrangement.End -> arrayOf(KOBWEB_ARRANGE_END)
     Arrangement.Start -> arrayOf(KOBWEB_ARRANGE_START)
     is Arrangement.HorizontalOrVertical -> this.toClasses()
-    is SpacedHorizontalAligned -> classes
 }
 
 fun Arrangement.Vertical.toClasses() = when (this) {
     Arrangement.Top -> arrayOf(KOBWEB_ARRANGE_TOP)
     Arrangement.Bottom -> arrayOf(KOBWEB_ARRANGE_BOTTOM)
     is Arrangement.HorizontalOrVertical -> toClasses()
-    is SpacedAligned -> classes
-    is SpacedVerticalAligned -> classes
 }
 
 fun Arrangement.HorizontalOrVertical.toClasses() = when (this) {

--- a/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/style/KobwebComposeStyleSheet.kt
+++ b/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/style/KobwebComposeStyleSheet.kt
@@ -12,6 +12,7 @@ object KobwebComposeStyleSheet : StyleSheet() {
         initCol()
         initRow()
         initSpacer()
+        initArrangeSpacedByStyle()
     }
 
     private fun initBox() {
@@ -118,12 +119,12 @@ object KobwebComposeStyleSheet : StyleSheet() {
 
         // Default styles for children placement
 
-        ".kobweb-row.kobweb-arrange-start" { justifyContent(JustifyContent.FlexStart) }
-        ".kobweb-row.kobweb-arrange-center" { justifyContent(JustifyContent.Center) }
-        ".kobweb-row.kobweb-arrange-end" { justifyContent(JustifyContent.FlexEnd) }
-        ".kobweb-row.kobweb-arrange-space-evenly" { justifyContent(JustifyContent.SpaceEvenly) }
-        ".kobweb-row.kobweb-arrange-space-between" { justifyContent(JustifyContent.SpaceBetween) }
-        ".kobweb-row.kobweb-arrange-space-around" { justifyContent(JustifyContent.SpaceAround) }
+        ".kobweb-row.$KOBWEB_ARRANGE_START" { justifyContent(JustifyContent.FlexStart) }
+        ".kobweb-row.$KOBWEB_ARRANGE_CENTER" { justifyContent(JustifyContent.Center) }
+        ".kobweb-row.$KOBWEB_ARRANGE_END" { justifyContent(JustifyContent.FlexEnd) }
+        ".kobweb-row.$KOBWEB_ARRANGE_SPACE_EVENLY" { justifyContent(JustifyContent.SpaceEvenly) }
+        ".kobweb-row.$KOBWEB_ARRANGE_SPACE_BETWEEN" { justifyContent(JustifyContent.SpaceBetween) }
+        ".kobweb-row.$KOBWEB_ARRANGE_SPACE_AROUND" { justifyContent(JustifyContent.SpaceAround) }
 
         ".kobweb-row.kobweb-align-top" { alignItems(AlignItems.FlexStart) }
         ".kobweb-row.kobweb-align-center-vert" { alignItems(AlignItems.Center) }
@@ -144,12 +145,12 @@ object KobwebComposeStyleSheet : StyleSheet() {
 
         // Default styles for children placement
 
-        ".kobweb-col.kobweb-arrange-top" { justifyContent(JustifyContent.FlexStart) }
-        ".kobweb-col.kobweb-arrange-center" { justifyContent(JustifyContent.Center) }
-        ".kobweb-col.kobweb-arrange-bottom" { justifyContent(JustifyContent.FlexEnd) }
-        ".kobweb-col.kobweb-arrange-space-evenly" { justifyContent(JustifyContent.SpaceEvenly) }
-        ".kobweb-col.kobweb-arrange-space-between" { justifyContent(JustifyContent.SpaceBetween) }
-        ".kobweb-col.kobweb-arrange-space-around" { justifyContent(JustifyContent.SpaceAround) }
+        ".kobweb-col.$KOBWEB_ARRANGE_TOP" { justifyContent(JustifyContent.FlexStart) }
+        ".kobweb-col.$KOBWEB_ARRANGE_CENTER" { justifyContent(JustifyContent.Center) }
+        ".kobweb-col.$KOBWEB_ARRANGE_BOTTOM" { justifyContent(JustifyContent.FlexEnd) }
+        ".kobweb-col.$KOBWEB_ARRANGE_SPACE_EVENLY" { justifyContent(JustifyContent.SpaceEvenly) }
+        ".kobweb-col.$KOBWEB_ARRANGE_SPACE_BETWEEN" { justifyContent(JustifyContent.SpaceBetween) }
+        ".kobweb-col.$KOBWEB_ARRANGE_SPACE_AROUND" { justifyContent(JustifyContent.SpaceAround) }
 
         ".kobweb-col.kobweb-align-start" { alignItems(AlignItems.FlexStart) }
         ".kobweb-col.kobweb-align-center-horiz" { alignItems(AlignItems.Center) }


### PR DESCRIPTION
## Description
The current implementation of the `Arrangement` API is missing the `spacedBy` function, provided by Compose UI. This PR enables the API to support `Arrangement` with spacing between the children elements for the given container.

> [!IMPORTANT]
> Compose UI also supports negative values for the `spacedBy` function. As we are using `gap` for adding the space between the children of a `Colunm` or a `Row`, and `gap` only accepts values within [0, Infinity], we are ignoring negative values.

## Comparison with Jetpack Compose
The following examples compare the implementation on Kobweb and Jetpack Compose on Android. The structure of the Composable will be:
```
Column(600x600, border 1 solid black)
    Row(fillMaxWidth, verticalAlignment = Alignment.CenterVertically) x 4
        Button
```

<table style="width: 100%">
  <thead>
    <tr>
      <th>Kobweb</th>
      <th>Jetpack Compose</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td colspan="2">
        <pre><code>Column(
verticalArrangement = 
  Arrangement.spacedBy(space = 16.px)
)
  Row(/*no-gap/spaced-by*/) x4</code></pre>
      </td>
    </tr>
    <tr>
      <td>
        <img src="https://github.com/varabyte/kobweb/assets/3229661/9479441c-64a9-480e-b12f-42cae6022da0" />
      </td>
      <td>
        <img src="https://github.com/varabyte/kobweb/assets/3229661/322fc02c-a2e6-48a0-a0c8-e21f87843b3c" />
      </td>
    </tr>
    <tr>
      <td colspan="2">
        <pre><code>Column(
verticalArrangement = 
  Arrangement.spacedBy(
    space = 16.px, 
    alignment = Alignment.CenterVertically,
  )
)
  Row(/*no-gap/spaced-by*/) x4</code></pre>
      </td>
    </tr>
    <tr>
      <td>
        <img src="https://github.com/varabyte/kobweb/assets/3229661/a56bd76a-cdef-408d-beb4-4d96627cece3" />
      </td>
      <td>
        <img src="https://github.com/varabyte/kobweb/assets/3229661/951cb24c-04e7-4572-9548-22cb41de73d5" />
      </td>
    </tr>
    <tr>
      <td colspan="2">
        <pre><code>Column(
verticalArrangement = 
  Arrangement.spacedBy(
    space = 16.px, 
    alignment = Alignment.Bottom,
  )
)
  Row(/*no-gap/spaced-by*/) x4</code></pre>
      </td>
    </tr>
    <tr>
      <td>
        <img src="https://github.com/varabyte/kobweb/assets/3229661/f88e7c58-b34a-46d4-939d-35d354acce2d" />
      </td>
      <td>
        <img src="https://github.com/varabyte/kobweb/assets/3229661/0f3a6720-3f58-4050-8642-cdd06343387d" />
      </td>
    </tr>
    <tr>
      <td colspan="2">
        <pre><code>Column(
verticalArrangement = 
  Arrangement.spacedBy(
    space = 16.px, 
    alignment = Alignment.CenterVertically,
  )
)
  Row(
    horizontalArrangement =
      Arrangement.spacedBy(space = 16.px),
  )
  Row(
    horizontalArrangement =
      Arrangement.spacedBy(
        space = 16.px,
        alignment = Alignment.Start,
      ),
  )
  Row(
    horizontalArrangement =
      Arrangement.spacedBy(
        space = 16.px,
        alignment = Alignment.CenterHorizontally,
      ),
  )
  Row(
    horizontalArrangement =
      Arrangement.spacedBy(
        space = 16.px,
        alignment = Alignment.End,
      ),
  )</code></pre>
      </td>
    </tr>
    <tr>
      <td>
        <img src="https://github.com/varabyte/kobweb/assets/3229661/1bebff20-a170-41b7-bcc0-522b3ff1abc4" />
      </td>
      <td>
        <img src="https://github.com/varabyte/kobweb/assets/3229661/4c6d937d-d17f-4222-a546-b985c9928adb" />
      </td>
    </tr>
  </tbody>
</table>

