### PR TITLE
docs(architecture): Update outdated reference to Kobweb CLI/Binary in ARCHITECTURE.md file

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -24,7 +24,7 @@ Kobweb is divided into the following parts:
 
 ## Binary
 
-**Folder: `cli`**
+Formerly part of this repository in `cli` folder, it has been moved to its separate repository, refer to [Kobweb CLI](https://github.com/varabyte/kobweb-cli)
 
 The binary will be most users' initial experience with Kobweb.
 


### PR DESCRIPTION
It looks like 3 Years ago, the Kobweb CLI/Binary was in a folder called `cli` in the same repository, later it was moved to [kobweb-cli](https://github.com/varabyte/kobweb-cli) in a separate repository, this PR is one minimal way of updating the reference

**Not directly related**:

The `gradle-plugins` folder also seems to be moved somewhere else

![image](https://github.com/varabyte/kobweb/assets/73608287/723c6a81-6183-4d31-9247-241c292097b5)

The description might also be outdated, the description indicates markdown Gradle plugin is not supported yet but will be in the future

If I were you, I would add links in markdown files like this

```
[cli](./cli)
```

Not only would it make it easier to navigate while viewing the file in both Github and the local clone of the repository, it also makes it easier to find outdated links and references 

even in simple projects as it can get bigger quickly later.

Alternatively use more complex solutions to generate the markdown files in source code in any language that is statically typed to eliminate the outdated code, references, and hardcoded values