### PR TITLE
Pass explicit inputs to tasks

### DIFF
--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/KobwebApplicationPlugin.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/KobwebApplicationPlugin.kt
@@ -6,6 +6,8 @@ import com.varabyte.kobweb.gradle.application.extensions.app
 import com.varabyte.kobweb.gradle.application.extensions.createAppBlock
 import com.varabyte.kobweb.gradle.application.extensions.export
 import com.varabyte.kobweb.gradle.application.extensions.index
+import com.varabyte.kobweb.gradle.application.extensions.remoteDebugging
+import com.varabyte.kobweb.gradle.application.extensions.server
 import com.varabyte.kobweb.gradle.application.ksp.kspBackendFile
 import com.varabyte.kobweb.gradle.application.ksp.kspFrontendFile
 import com.varabyte.kobweb.gradle.application.tasks.KobwebBrowserCacheIdTask
@@ -115,7 +117,7 @@ class KobwebApplicationPlugin @Inject constructor(
         val buildTarget = project.kobwebBuildTarget
 
         val kobwebGenSiteIndexTask = project.tasks.register<KobwebGenerateSiteIndexTask>(
-            "kobwebGenSiteIndex", KobwebGenIndexConfInputs(kobwebConf), buildTarget, kobwebBlock.app.index
+            "kobwebGenSiteIndex", kobwebBlock.app, KobwebGenIndexConfInputs(kobwebConf), buildTarget
         )
 
         val kobwebCopySupplementalResourcesTask = project.tasks.register<KobwebCopySupplementalResourcesTask>(
@@ -131,7 +133,9 @@ class KobwebApplicationPlugin @Inject constructor(
             .register<KobwebCreateServerScriptsTask>("kobwebCreateServerScripts")
         val kobwebStartTask = run {
             val reuseServer = project.findProperty("kobwebReuseServer")?.let { it.toString().toBoolean() } ?: true
-            project.tasks.register<KobwebStartTask>("kobwebStart", kobwebBlock, env, runLayout, reuseServer)
+            project.tasks.register<KobwebStartTask>(
+                "kobwebStart", kobwebBlock.app.server.remoteDebugging, env, runLayout, reuseServer
+            )
         }
 
         val kobwebSyncServerPluginJarsTask = project.tasks.register<Sync>("kobwebSyncServerPluginJars") {
@@ -251,6 +255,7 @@ class KobwebApplicationPlugin @Inject constructor(
 
             val kobwebGenSiteEntryTask = project.tasks.register<KobwebGenerateSiteEntryTask>(
                 "kobwebGenSiteEntry",
+                appBlock,
                 kobwebConf.site.routePrefix,
                 buildTarget,
                 KobwebGenSiteEntryConfInputs(kobwebConf),
@@ -350,7 +355,7 @@ class KobwebApplicationPlugin @Inject constructor(
             }
 
             val kobwebGenApisFactoryTask = project.tasks
-                .register<KobwebGenerateApisFactoryTask>("kobwebGenApisFactory")
+                .register<KobwebGenerateApisFactoryTask>("kobwebGenApisFactory", kobwebBlock.app)
 
             kobwebGenApisFactoryTask.configure {
                 kspGenFile.set(project.kspBackendFile(jvmTarget))

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebGenerateApisFactoryTask.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebGenerateApisFactoryTask.kt
@@ -1,6 +1,6 @@
 package com.varabyte.kobweb.gradle.application.tasks
 
-import com.varabyte.kobweb.gradle.application.extensions.app
+import com.varabyte.kobweb.gradle.application.extensions.AppBlock
 import com.varabyte.kobweb.gradle.application.templates.createApisFactoryImpl
 import com.varabyte.kobweb.gradle.core.util.searchZipFor
 import com.varabyte.kobweb.ksp.KOBWEB_METADATA_BACKEND
@@ -15,8 +15,9 @@ import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
+import javax.inject.Inject
 
-abstract class KobwebGenerateApisFactoryTask :
+abstract class KobwebGenerateApisFactoryTask @Inject constructor(private val appBlock: AppBlock) :
     KobwebGenerateTask("Generate Kobweb code for the server") {
     @get:Optional
     @get:InputFile
@@ -26,7 +27,7 @@ abstract class KobwebGenerateApisFactoryTask :
     abstract val compileClasspath: ConfigurableFileCollection
 
     @OutputDirectory // needs to be dir to be registered as a kotlin srcDir
-    fun getGenApisFactoryFile() = kobwebBlock.app.getGenJvmSrcRoot()
+    fun getGenApisFactoryFile() = appBlock.getGenJvmSrcRoot()
 
     @TaskAction
     fun execute() {

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebGenerateSiteEntryTask.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebGenerateSiteEntryTask.kt
@@ -3,7 +3,6 @@ package com.varabyte.kobweb.gradle.application.tasks
 import com.varabyte.kobweb.common.navigation.RoutePrefix
 import com.varabyte.kobweb.gradle.application.BuildTarget
 import com.varabyte.kobweb.gradle.application.extensions.AppBlock
-import com.varabyte.kobweb.gradle.application.extensions.app
 import com.varabyte.kobweb.gradle.application.templates.SilkSupport
 import com.varabyte.kobweb.gradle.application.templates.createMainFunction
 import com.varabyte.kobweb.gradle.core.util.hasDependencyNamed
@@ -36,20 +35,21 @@ class KobwebGenSiteEntryConfInputs(
 }
 
 abstract class KobwebGenerateSiteEntryTask @Inject constructor(
+    private val appBlock: AppBlock,
     @get:Input val routePrefix: String,
     @get:Input val buildTarget: BuildTarget,
     @get:Nested val confInputs: KobwebGenSiteEntryConfInputs,
 ) : KobwebGenerateTask("Generate entry code (i.e. main.kt) for this Kobweb project") {
     @get:Input
-    val cleanUrls: Provider<Boolean> = kobwebBlock.app.cleanUrls
+    val cleanUrls: Provider<Boolean> = appBlock.cleanUrls
 
     @get:Input
     @get:Optional
     val legacyRouteRedirectStrategy: Provider<AppBlock.LegacyRouteRedirectStrategy> =
-        kobwebBlock.app.legacyRouteRedirectStrategy
+        appBlock.legacyRouteRedirectStrategy
 
     @get:Input
-    val globals: Provider<Map<String, String>> = kobwebBlock.app.globals
+    val globals: Provider<Map<String, String>> = appBlock.globals
 
     @get:InputFile
     abstract val appDataFile: RegularFileProperty
@@ -65,7 +65,7 @@ abstract class KobwebGenerateSiteEntryTask @Inject constructor(
             }
 
     @OutputDirectory // needs to be dir to be registered as a kotlin srcDir
-    fun getGenMainFile() = kobwebBlock.app.getGenJsSrcRoot()
+    fun getGenMainFile() = appBlock.getGenJsSrcRoot()
 
     @TaskAction
     fun execute() {

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebGenerateSiteIndexTask.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebGenerateSiteIndexTask.kt
@@ -5,7 +5,7 @@ package com.varabyte.kobweb.gradle.application.tasks
 import com.varabyte.kobweb.common.navigation.RoutePrefix
 import com.varabyte.kobweb.gradle.application.BuildTarget
 import com.varabyte.kobweb.gradle.application.extensions.AppBlock
-import com.varabyte.kobweb.gradle.application.extensions.app
+import com.varabyte.kobweb.gradle.application.extensions.index
 import com.varabyte.kobweb.gradle.application.templates.createIndexFile
 import com.varabyte.kobweb.gradle.core.metadata.LibraryIndexMetadata
 import com.varabyte.kobweb.gradle.core.metadata.LibraryMetadata
@@ -52,10 +52,12 @@ class KobwebGenIndexConfInputs(
 }
 
 abstract class KobwebGenerateSiteIndexTask @Inject constructor(
+    private val appBlock: AppBlock,
     @get:Nested val confInputs: KobwebGenIndexConfInputs,
     @get:Input val buildTarget: BuildTarget,
-    @get:Nested val indexBlock: AppBlock.IndexBlock
 ) : KobwebGenerateTask("Generate an index.html file for this Kobweb project") {
+    @get:Nested
+    val indexBlock: AppBlock.IndexBlock = appBlock.index
 
     // No one should define their own root `public/index.html` files anywhere in their resources.
     @InputFiles
@@ -87,7 +89,7 @@ abstract class KobwebGenerateSiteIndexTask @Inject constructor(
         get() = dependencies.hasDependencyNamed("com.varabyte.kobwebx:silk-icons-mdi")
 
     @OutputFile
-    fun getGenIndexFile(): Provider<RegularFile> = kobwebBlock.app.getGenJsResRoot().map { it.file("index.html") }
+    fun getGenIndexFile(): Provider<RegularFile> = appBlock.getGenJsResRoot().map { it.file("index.html") }
 
     @TaskAction
     fun execute() {


### PR DESCRIPTION
This is required for compatibility with Gradle configuration cache.