### PR TITLE
Clean up markdown task outputs

### DIFF
--- a/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/tasks/ConvertMarkdownTask.kt
+++ b/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/tasks/ConvertMarkdownTask.kt
@@ -53,13 +53,14 @@ abstract class ConvertMarkdownTask @Inject constructor(markdownBlock: MarkdownBl
 
     @OutputDirectory
     fun getGenDir(): Provider<Directory> {
-        return markdownBlock.getGenJsSrcRoot().zip(pagesPackage) { genRoot, pagesPackage ->
+        return markdownBlock.getGenJsSrcRoot("convert").zip(pagesPackage) { genRoot, pagesPackage ->
             genRoot.dir(project.prefixQualifiedPackage(pagesPackage).replace(".", "/"))
         }
     }
 
     @TaskAction
     fun execute() {
+        getGenDir().get().asFile.clearDirectory()
         val cache = NodeCache(
             parser = markdownFeatures.createParser(),
             roots = getMarkdownRoots().get() + generatedMarkdownDir.asFileTree

--- a/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/tasks/MarkdownTask.kt
+++ b/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/tasks/MarkdownTask.kt
@@ -55,6 +55,12 @@ abstract class MarkdownTask @Inject constructor(
         return rootPath.relativize(Path(this.pathString))
     }
 
+    /** Recursively delete the contents of this directory without deleting the directory itself. */
+    protected fun File.clearDirectory() {
+        deleteRecursively()
+        mkdirs()
+    }
+
     protected fun packagePartsFor(mdFile: RelativePath): List<String> {
         val mdPathRel = mdFile.toPath().invariantSeparatorsPathString
 

--- a/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/tasks/ProcessMarkdownTask.kt
+++ b/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/tasks/ProcessMarkdownTask.kt
@@ -55,10 +55,12 @@ abstract class ProcessMarkdownTask @Inject constructor(markdownBlock: MarkdownBl
     fun getGenSrcDir() = markdownBlock.getGenJsSrcRoot("process")
 
     @OutputDirectory
-    fun getGenResDir() = markdownBlock.getGenJsResRoot()
+    fun getGenResDir() = markdownBlock.getGenJsResRoot("process")
 
     @TaskAction
     fun execute() {
+        getGenSrcDir().get().asFile.clearDirectory()
+        getGenResDir().get().asFile.clearDirectory()
         val process = markdownBlock.process.orNull ?: return
         val parser = markdownFeatures.createParser()
         val markdownEntries = buildList {


### PR DESCRIPTION
- Ensure stale outputs are deleted
- Split task outputs into their own subdirectories