### PR TITLE
Remove usage of `project.group` at task execution time

### DIFF
--- a/tools/gradle-plugins/core/src/main/kotlin/com/varabyte/kobweb/gradle/core/util/ProjectExtensions.kt
+++ b/tools/gradle-plugins/core/src/main/kotlin/com/varabyte/kobweb/gradle/core/util/ProjectExtensions.kt
@@ -49,16 +49,6 @@ fun Project.getSourceFilesWithRoots(platform: TargetPlatform<*>): Sequence<RootA
     return project.getFilesWithRoots(platform) { sourceSet -> sourceSet.kotlin }
 }
 
-/**
- * Using a [Project], get the fully qualified packages name, e.g. ".pages" -> "org.example.pages"
- */
-fun Project.prefixQualifiedPackage(relPathMaybe: String): String {
-    return when {
-        relPathMaybe.startsWith('.') -> "${project.group}$relPathMaybe"
-        else -> relPathMaybe
-    }
-}
-
 private fun Project.getDependencyResultsFromConfiguration(configurationName: String): List<ResolvedDependencyResult> {
     return configurations[configurationName].incoming.resolutionResult.allDependencies
         .mapNotNull { it as? ResolvedDependencyResult }

--- a/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/KobwebxMarkdownPlugin.kt
+++ b/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/KobwebxMarkdownPlugin.kt
@@ -41,11 +41,13 @@ class KobwebxMarkdownPlugin : Plugin<Project> {
             processTask.configure {
                 resources.set(project.getResourceSources(jsTarget))
                 pagesPackage.set(kobwebBlock.pagesPackage)
+                projectGroup.set(project.group)
             }
             convertTask.configure {
                 resources.set(project.getResourceSources(jsTarget))
                 generatedMarkdownDir.set(processTask.map { it.getGenResDir().get() })
                 pagesPackage.set(kobwebBlock.pagesPackage)
+                projectGroup.set(project.group)
                 dependsOnMarkdownArtifact.set(
                     project.getJsDependencyResults().hasDependencyNamed("com.varabyte.kobwebx:kobwebx-markdown")
                 )

--- a/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/ext/kobwebcall/KobwebCall.kt
+++ b/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/ext/kobwebcall/KobwebCall.kt
@@ -1,8 +1,7 @@
 package com.varabyte.kobwebx.gradle.markdown.ext.kobwebcall
 
-import com.varabyte.kobweb.gradle.core.util.prefixQualifiedPackage
+import com.varabyte.kobweb.project.common.PackageUtils
 import org.commonmark.node.CustomNode
-import org.gradle.api.Project
 
 /**
  * A block which represents a method call to insert into the final output.
@@ -24,9 +23,9 @@ class KobwebCall(val partiallyQualifiedName: String, var appendBrace: Boolean = 
      * * `.test` -> `org.example.myproject.test()`
      * * `test()` -> `test()`
      */
-    fun toFqn(project: Project): String {
+    fun toFqn(projectGroup: String): String {
         return buildString {
-            append(project.prefixQualifiedPackage(partiallyQualifiedName))
+            append(PackageUtils.resolvePackageShortcut(projectGroup, partiallyQualifiedName))
             if (partiallyQualifiedName.last().isLetterOrDigit() && !appendBrace) {
                 append("()")
             }

--- a/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/tasks/MarkdownTask.kt
+++ b/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/tasks/MarkdownTask.kt
@@ -3,7 +3,7 @@ package com.varabyte.kobwebx.gradle.markdown.tasks
 import com.varabyte.kobweb.common.lang.packageConcat
 import com.varabyte.kobweb.common.lang.toPackageName
 import com.varabyte.kobweb.gradle.core.tasks.KobwebTask
-import com.varabyte.kobweb.gradle.core.util.prefixQualifiedPackage
+import com.varabyte.kobweb.project.common.PackageUtils
 import com.varabyte.kobwebx.gradle.markdown.MarkdownBlock
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.RelativePath
@@ -22,11 +22,12 @@ import kotlin.io.path.invariantSeparatorsPathString
 abstract class MarkdownTask @Inject constructor(
     @get:Internal protected val markdownBlock: MarkdownBlock,
     desc: String
-) :
-    KobwebTask(desc) {
-
+) : KobwebTask(desc) {
     @get:Input
     abstract val pagesPackage: Property<String>
+
+    @get:Input
+    abstract val projectGroup: Property<Any>
 
     private val rootPath get() = Path(markdownBlock.markdownPath.get())
 
@@ -70,7 +71,8 @@ abstract class MarkdownTask @Inject constructor(
     }
 
     protected fun absolutePackageFor(packageParts: List<String>): String {
-        return project.prefixQualifiedPackage(
+        return PackageUtils.resolvePackageShortcut(
+            projectGroup.get().toString(),
             pagesPackage.get().packageConcat(packageParts.joinToString("."))
         )
     }


### PR DESCRIPTION
This is required for compatibility with configuration cache.