### PR TITLE
Fixed a formatting issue in readme at the section animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1322,11 +1322,10 @@ an animation that uses them, which you can pass into the `Modifier.animation` mo
 > @Suppress("PRIVATE_KEYFRAMES")
 > private val ExampleKeyframes = Keyframes { /* ... */ }
 > // Or, `private val _ExampleKeyframes`
-
 >
 > @InitSilk
 > fun registerPrivateAnim(ctx: InitSilkContext) {
-> ctx.stylesheet.registerKeyframes("example", ExampleKeyframes)
+>     ctx.stylesheet.registerKeyframes("example", ExampleKeyframes)
 > }
 > ```
 >


### PR DESCRIPTION
Fixed a formatting issue in readme at the section [animations](https://github.com/FromWau/kobweb#animations)

Before fix:
![image](https://github.com/varabyte/kobweb/assets/56253401/96ed93fa-2d83-419e-a8f2-b5571ff44413)

After fix:
![image](https://github.com/varabyte/kobweb/assets/56253401/3f7f7d53-fe26-4b00-a950-644efffc23fa)
