### PR TITLE
Declare all inputs for markdown tasks

### DIFF
--- a/tools/gradle-plugins/core/src/main/kotlin/com/varabyte/kobweb/gradle/core/util/ProjectExtensions.kt
+++ b/tools/gradle-plugins/core/src/main/kotlin/com/varabyte/kobweb/gradle/core/util/ProjectExtensions.kt
@@ -6,7 +6,6 @@ import com.varabyte.kobweb.gradle.core.kmp.kotlin
 import com.varabyte.kobweb.gradle.core.tasks.KobwebGenerateModuleMetadataTask
 import org.gradle.api.Project
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
-import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.provider.Provider
 import org.gradle.kotlin.dsl.get
@@ -112,36 +111,4 @@ fun Project.toUidString(): String {
     val hash = digest.digest(rawText.toByteArray(Charsets.UTF_8))
 
     return hash.joinToString("") { "%02x".format(it) }.uppercase()
-}
-
-/**
- * Return the Gradle build script in the current project.
- *
- * If a task depends on a Kobweb block property, then you want to make sure it is invalidated if that changes. However,
- * passing the block into the task with an `@Input` annotation is not always possible, as the block may not be
- * serializable, which is a requirement for Gradle inputs and outputs. (For example, this can happen if one of the
- * properties accepts a lambda which pulls in some property into its closure.)
- *
- * As a workaround for those cases, you can do something like this:
- *
- * ```
- * abstract class ExampleTask(private val someBlock: SomeBlock) {
- *   @InputFiles
- *   @PathSensitive(PathSensitivity.RELATIVE)
- *   fun getBuildScripts(): List<File> = projectLayout.getBuildScripts().toList()
- * }
- * ```
- *
- * Note that the above case doesn't play friendly with Gradle's configuration cache, so it should only be used as a last
- * resort.
- *
- * The method technically returns a collection of files, which could happen if the project has both a `build.gradle` and
- * a `build.gradle.kts` file. However, in practice, we always expect this to return a single entry, as most projects
- * would only ever have one or the other.
- */
-// TODO: If possible, kill this approach and find a way to make Kobweb blocks safe to use as inputs even with lambdas.
-fun ProjectLayout.getBuildScripts(): List<File> {
-    return sequenceOf("build.gradle", "build.gradle.kts")
-        .mapNotNull { script -> this.projectDirectory.file(script).asFile.takeIf { it.exists() } }
-        .toList()
 }

--- a/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/MarkdownFeatures.kt
+++ b/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/MarkdownFeatures.kt
@@ -11,6 +11,7 @@ import org.commonmark.ext.task.list.items.TaskListItemsExtension
 import org.commonmark.parser.IncludeSourceSpans
 import org.commonmark.parser.Parser
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
 
 /**
  * List feature extensions to markdown that this plugin supports.
@@ -31,6 +32,7 @@ abstract class MarkdownFeatures {
      *
      * See also: https://github.com/commonmark/commonmark-java#autolink
      */
+    @get:Input
     abstract val autolink: Property<Boolean>
 
     /**
@@ -38,6 +40,7 @@ abstract class MarkdownFeatures {
      *
      * See also: https://github.com/commonmark/commonmark-java#yaml-front-matter
      */
+    @get:Input
     abstract val frontMatter: Property<Boolean>
 
     /**
@@ -53,6 +56,7 @@ abstract class MarkdownFeatures {
      * org.example.myproject.components.widgets.VisitorCounter()
      * ```
      */
+    @get:Input
     abstract val kobwebCall: Property<Boolean>
 
     /**
@@ -61,6 +65,7 @@ abstract class MarkdownFeatures {
      * By default, it is curly braces `{}` but you can change the character if this
      * causes a problem in your project for some unforeseeable reason.
      */
+    @get:Input
     abstract val kobwebCallDelimiters: Property<Pair<Char, Char>>
 
     /**
@@ -69,6 +74,7 @@ abstract class MarkdownFeatures {
      * See also: https://github.com/commonmark/commonmark-java#tables
      * See also: https://docs.github.com/en/github/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables
      */
+    @get:Input
     abstract val tables: Property<Boolean>
 
     /**
@@ -81,6 +87,7 @@ abstract class MarkdownFeatures {
      *
      * See also: https://github.com/commonmark/commonmark-java#task-list-items
      */
+    @get:Input
     abstract val taskList: Property<Boolean>
 
     init {

--- a/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/MarkdownHandlers.kt
+++ b/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/MarkdownHandlers.kt
@@ -33,6 +33,9 @@ import org.commonmark.node.Text
 import org.commonmark.node.ThematicBreak
 import org.gradle.api.Project
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Element
 import org.jsoup.nodes.TextNode
@@ -93,6 +96,7 @@ abstract class MarkdownHandlers @Inject constructor(project: Project, newDefault
      * tree). To indicate this (expectedly rare) case, this value may be set to the empty string to disable it.
      */
     @Deprecated("Use the `defaultRoot` property in the parent markdown block instead.")
+    @get:Internal
     val defaultRoot: Property<String> = newDefaultRoot
 
     /**
@@ -100,6 +104,7 @@ abstract class MarkdownHandlers @Inject constructor(project: Project, newDefault
      *
      * If the user's project doesn't have a dependency on the Silk library, this should be set to false.
      */
+    @get:Input
     abstract val useSilk: Property<Boolean>
 
     /**
@@ -115,6 +120,7 @@ abstract class MarkdownHandlers @Inject constructor(project: Project, newDefault
      *
      * See also [idGenerator] if you need to override the default algorithm used for generating these IDs.
      */
+    @get:Input
     abstract val generateHeaderIds: Property<Boolean>
 
     /**
@@ -132,34 +138,59 @@ abstract class MarkdownHandlers @Inject constructor(project: Project, newDefault
      *
      * @see generateHeaderIds
      */
+    @get:Nested
     abstract val idGenerator: Property<(String) -> String>
 
+    @get:Nested
     abstract val text: Property<NodeScope.(Text) -> String>
+    @get:Nested
     abstract val img: Property<NodeScope.(Image) -> String>
+    @get:Nested
     abstract val heading: Property<NodeScope.(Heading) -> String>
+    @get:Nested
     abstract val p: Property<NodeScope.(Paragraph) -> String>
+    @get:Nested
     abstract val br: Property<NodeScope.(HardLineBreak) -> String>
+    @get:Nested
     abstract val a: Property<NodeScope.(Link) -> String>
+    @get:Nested
     abstract val em: Property<NodeScope.(Emphasis) -> String>
+    @get:Nested
     abstract val strong: Property<NodeScope.(StrongEmphasis) -> String>
+    @get:Nested
     abstract val hr: Property<NodeScope.(ThematicBreak) -> String>
+    @get:Nested
     abstract val ul: Property<NodeScope.(BulletList) -> String>
+    @get:Nested
     abstract val ol: Property<NodeScope.(OrderedList) -> String>
+    @get:Nested
     abstract val li: Property<NodeScope.(ListItem) -> String>
+    @get:Nested
     abstract val code: Property<NodeScope.(FencedCodeBlock) -> String>
+    @get:Nested
     abstract val inlineCode: Property<NodeScope.(Code) -> String>
+    @get:Nested
     abstract val blockquote: Property<NodeScope.(BlockQuote) -> String>
+    @get:Nested
     abstract val table: Property<NodeScope.(TableBlock) -> String>
+    @get:Nested
     abstract val thead: Property<NodeScope.(TableHead) -> String>
+    @get:Nested
     abstract val tbody: Property<NodeScope.(TableBody) -> String>
+    @get:Nested
     abstract val tr: Property<NodeScope.(TableRow) -> String>
+    @get:Nested
     abstract val td: Property<NodeScope.(TableCell) -> String>
+    @get:Nested
     abstract val th: Property<NodeScope.(TableCell) -> String>
 
     /** Handler which is fed the raw text (name and attributes) within an opening tag, e.g. `span id="demo"` */
+    @get:Nested
     abstract val rawTag: Property<NodeScope.(String) -> String>
+    @get:Nested
     abstract val inlineTag: Property<NodeScope.(HtmlInline) -> String>
 
+    @get:Nested
     abstract val html: Property<NodeScope.(HtmlBlock) -> String>
 
     fun String.escapeSingleQuotedText() = escapeQuotes().escapeDollars()

--- a/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/tasks/MarkdownTask.kt
+++ b/tools/gradle-plugins/extensions/markdown/src/main/kotlin/com/varabyte/kobwebx/gradle/markdown/tasks/MarkdownTask.kt
@@ -30,7 +30,10 @@ abstract class MarkdownTask @Inject constructor(
     @get:InputFiles
     abstract val markdownResources: ConfigurableFileCollection
 
-    private val rootPath get() = Path(markdownBlock.markdownPath.get())
+    @get:Input
+    val markdownPath = markdownBlock.markdownPath
+
+    private val rootPath get() = Path(markdownPath.get())
 
     protected fun funNameFor(mdFile: File): String {
         // The suggested replacement for "capitalize" is awful


### PR DESCRIPTION
We mark lambda inputs with `@Nested`, which ensures tasks are rerun when the lambda is changed.