### PR TITLE
Fix empty css layer name being registered as anonymous layer

### DIFF
--- a/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/theme/SilkTheme.kt
+++ b/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/theme/SilkTheme.kt
@@ -107,8 +107,10 @@ class MutableSilkTheme {
             RestrictedKind::class -> SilkLayer.RESTRICTED_STYLES
             GeneralKind::class -> SilkLayer.GENERAL_STYLES
             else -> error("Unknown kind: $kind")
-        }.layerName.takeIf { it.isNotEmpty() } // In case user passes in ""
-        finalLayer?.let { _cssLayersFor[name] = it }
+        }.layerName
+        finalLayer
+            .takeIf { it.isNotEmpty() } // If the user passes in "", no layer should be registered
+            ?.let { _cssLayersFor[name] = it }
 
         if (style is ExtendingCssStyle) {
             _cssStyleDependencies.getOrPut(style) { mutableListOf() }.add(style.baseStyle)

--- a/frontend/silk-foundation/src/jsTest/kotlin/com/varabyte/kobweb/silk/CssStyleTest.kt
+++ b/frontend/silk-foundation/src/jsTest/kotlin/com/varabyte/kobweb/silk/CssStyleTest.kt
@@ -73,6 +73,21 @@ class CssStyleTest {
             .inOrder()
     }
 
+
+    @Test
+    fun cssStyleEmptyLayerNameResultsInNoLayer() {
+        val stylesheet = StyleSheet()
+        // Styles must be non-empty to be registered
+        val BaseStyle = CssStyle.base<ComponentKind> { Modifier.color(Colors.Red) }
+        _SilkTheme = MutableSilkTheme().apply {
+            registerStyle("base-style", BaseStyle, layer = "")
+        }.let(::ImmutableSilkTheme)
+        SilkTheme.registerStylesInto(stylesheet)
+        val styleRule = stylesheet.cssRules.first()
+        assertThat(styleRule).isInstanceOf<CSSStyleRuleDeclaration>()
+        assertThat(styleRule.header).isEqualTo(".base-style")
+    }
+
     @Test
     fun cssStyleExtendedClasses() {
         val BaseStyle = CssStyle { }


### PR DESCRIPTION
If a user passes an empty string when registering a style, or in an `@CssLayer` annotation, the style should be registered without any layers - not in an anonymous, nameless layer.