### PR TITLE
Rework `!important` hack to avoid flicker

### DIFF
--- a/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/SilkFoundationStyles.kt
+++ b/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/SilkFoundationStyles.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.*
 import com.varabyte.kobweb.compose.KobwebComposeStyles
 import com.varabyte.kobweb.silk.init.InitSilkContext
 import com.varabyte.kobweb.silk.init.initSilk
+import com.varabyte.kobweb.silk.style.breakpoint.SilkBreakpointDisplayStyles
 import org.jetbrains.compose.web.css.*
 
 /**
@@ -35,4 +36,5 @@ fun SilkFoundationStyles(initSilk: (InitSilkContext) -> Unit = {}) {
     }
 
     Style(SilkStyleSheet)
+    SilkBreakpointDisplayStyles()
 }


### PR DESCRIPTION
Before, the following was happening when an export Kobweb page was visited which used a conditional breakpoint style:
1. The browser loaded the export HTML, which correctly included the `!important` styling
2. When the JS was loaded, the styles were overridden by Silk initialization, which did not use `!important`
3. On the next event loop, the Silk hack overwrote the styles to include `!important`

This meant that any styling that depended on the `!important` was broken between steps 2 and 3. This would manifest as a layout flicker.

The new approach bypasses Compose HTML styling altogether and instead registers these breakpoint styles directly to a stylesheet, effectively bypassing step 2.