### PR TITLE
Feature+routeprefix

### DIFF
--- a/frontend/kobweb-core/src/jsMain/kotlin/com/varabyte/kobweb/navigation/Anchor.kt
+++ b/frontend/kobweb-core/src/jsMain/kotlin/com/varabyte/kobweb/navigation/Anchor.kt
@@ -27,11 +27,11 @@ import org.w3c.dom.HTMLAnchorElement
  *   when visiting the new location (so you can return back to the current page), but [UpdateHistoryMode.REPLACE] can be
  *   used to create an effect where the new page "takes over" the current page in place.
  *
- * @param autoPrefix If true AND if a route prefix is configured for this site, auto-affix it to the front. For example,
- *   if the [href] parameter was set to "example/path" and the site's route prefix was set to "parent-site/nested", then
- *   the `href` value will be converted to "parent-site/nested/example/path". You usually want this to be true, unless
- *   you are intentionally linking outside this site's root folder while still staying in the same domain, e.g. you are
- *   linking to "parent-site/about".
+ * @param autoPrefix If true AND if a route prefix is configured for this site, auto-affix it to the front of [href] if
+ *   possible. For example, if the [href] parameter was set to "/about" and the site's route prefix was set to
+ *   "company/our-team", then the `href` value will be converted to "/company/our-team/about". You usually want this to
+ *   be true, unless you are intentionally linking outside this site's root folder while still staying in the same
+ *   domain, e.g. you are linking to "/company/other-team". See [RoutePrefix] for more information.
  */
 @Composable
 fun Anchor(
@@ -63,7 +63,11 @@ fun Anchor(
                     href,
                     updateHistoryMode ?: UpdateHistoryMode.PUSH,
                     openInternalLinksStrategy = openInternalLinksStrategy,
-                    openExternalLinksStrategy = openExternalLinksStrategy
+                    openExternalLinksStrategy = openExternalLinksStrategy,
+                    // No auto-prefix, as we handled it ourselves (see href modification above). We did this so that the
+                    // URL associated with the anchor element (that additionally shows up at the bottom of the browser
+                    // window) matches where we actually navigate to.
+                    autoPrefix = false
                 )
                 evt.preventDefault()
                 evt.stopPropagation()

--- a/frontend/kobweb-core/src/jsMain/kotlin/com/varabyte/kobweb/navigation/RoutePrefix.kt
+++ b/frontend/kobweb-core/src/jsMain/kotlin/com/varabyte/kobweb/navigation/RoutePrefix.kt
@@ -21,6 +21,14 @@ interface RoutePrefix {
      * Prepend this route prefix onto some target absolute path.
      *
      * If the path is a relative path, it will be returned unchanged.
+     *
+     * For example, if this route prefix's value is "prefix", then...
+     *
+     * * `path == "subdir"` -> `"subdir"`
+     * * `path == "/subdir"` -> `"/prefix/subdir"`
+     *
+     * By only working on absolute routes, we'll never accidentally append a route prefix onto a sub-route where any
+     * middle parts are missing.
      */
     fun prepend(path: String): String
 

--- a/frontend/kobweb-core/src/jsMain/kotlin/com/varabyte/kobweb/navigation/Router.kt
+++ b/frontend/kobweb-core/src/jsMain/kotlin/com/varabyte/kobweb/navigation/Router.kt
@@ -8,7 +8,6 @@ import kotlinx.browser.document
 import kotlinx.browser.window
 import org.jetbrains.compose.web.dom.Div
 import org.jetbrains.compose.web.dom.Text
-import org.w3c.dom.Element
 import org.w3c.dom.MutationObserver
 import org.w3c.dom.MutationObserverInit
 import org.w3c.dom.url.URL
@@ -351,14 +350,21 @@ class Router {
      *   [standards](https://www.rfc-editor.org/rfc/rfc3986#section-3.3) documentation.
      * @param updateHistoryMode How this new path should affect the history. See [UpdateHistoryMode] docs for more
      *   details. Note that this value will be ignored if [pathQueryAndFragment] refers to an external link.
+     * @param autoPrefix If true AND if a route prefix is configured for this site, auto-affix it to the front of the
+     *   [pathQueryAndFragment] if possible. For example, if the [pathQueryAndFragment] parameter was set to
+     *   "/about" and the site's route prefix was set to "company/our-team", then the `href` value will be converted to
+     *   "/company/our-team/about". You usually want this to be true, unless you are intentionally linking outside this
+     *   site's root folder while still staying in the same domain, e.g. you are linking to "/company/other-team". See
+     *   [RoutePrefix] for more information.
      */
     fun tryRoutingTo(
         pathQueryAndFragment: String,
         updateHistoryMode: UpdateHistoryMode = UpdateHistoryMode.PUSH,
-        openLinkStrategy: OpenLinkStrategy = OpenLinkStrategy.IN_PLACE
+        openLinkStrategy: OpenLinkStrategy = OpenLinkStrategy.IN_PLACE,
+        autoPrefix: Boolean = true,
     ): Boolean {
         @Suppress("NAME_SHADOWING") // Intentionally transformed
-        var pathQueryAndFragment = pathQueryAndFragment
+        var pathQueryAndFragment = RoutePrefix.prependIf(autoPrefix, pathQueryAndFragment)
         if (Route.isRoute(pathQueryAndFragment)) {
             pathQueryAndFragment = pathQueryAndFragment.normalize()
 
@@ -489,8 +495,9 @@ class Router {
         updateHistoryMode: UpdateHistoryMode = UpdateHistoryMode.PUSH,
         openInternalLinksStrategy: OpenLinkStrategy = OpenLinkStrategy.IN_PLACE,
         openExternalLinksStrategy: OpenLinkStrategy = OpenLinkStrategy.IN_NEW_TAB,
+        autoPrefix: Boolean = true,
     ) {
-        if (!tryRoutingTo(pathQueryAndFragment, updateHistoryMode, openInternalLinksStrategy)) {
+        if (!tryRoutingTo(pathQueryAndFragment, updateHistoryMode, openInternalLinksStrategy, autoPrefix)) {
             window.open(pathQueryAndFragment, openExternalLinksStrategy)
         }
     }

--- a/frontend/silk-widgets-kobweb/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/navigation/Link.kt
+++ b/frontend/silk-widgets-kobweb/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/navigation/Link.kt
@@ -9,6 +9,7 @@ import com.varabyte.kobweb.compose.ui.modifiers.*
 import com.varabyte.kobweb.compose.ui.toAttrs
 import com.varabyte.kobweb.navigation.Anchor
 import com.varabyte.kobweb.navigation.OpenLinkStrategy
+import com.varabyte.kobweb.navigation.RoutePrefix
 import com.varabyte.kobweb.navigation.UpdateHistoryMode
 import com.varabyte.kobweb.silk.style.ComponentKind
 import com.varabyte.kobweb.silk.style.CssStyle
@@ -87,9 +88,11 @@ val AlwaysUnderlinedLinkVariant = LinkStyle.addVariant {
  *   when visiting the new location (so you can return back to the current page), but [UpdateHistoryMode.REPLACE] can be
  *   used to create an effect where the new page "takes over" the current page in place.
  *
- * @param autoPrefix If true AND if a route prefix is configured for this site, auto-affix it to the front. You usually
- *   want this to be true, unless you are intentionally linking outside this site's root folder while still staying in
- *   the same domain.
+ * @param autoPrefix If true AND if a route prefix is configured for this site, auto-affix it to the front of [path] if
+ *   possible. For example, if the [path] parameter was set to "/about" and the site's route prefix was set to
+ *   "company/our-team", then the `href` value will be converted to "/company/our-team/about". You usually want this to
+ *   be true, unless you are intentionally linking outside this site's root folder while still staying in the same
+ *   domain, e.g. you are linking to "/company/other-team". See [RoutePrefix] for more information.
  */
 @Composable
 fun Link(

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/templates/MainTemplate.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/templates/MainTemplate.kt
@@ -243,16 +243,24 @@ fun createMainFunction(
 
             // Note: Below, we use %S when specifying key/value pairs. This prevents KotlinPoet from breaking
             // our text in the middle of a String.
+            addComment("The initial route used here comes from the browser as a source of truth, so don't auto-add")
+            addComment("a prefix even if this site uses one.")
             addCode(CodeBlock.Builder().apply {
-                addStatement("router.navigateTo(window.location.href.removePrefix(window.location.origin), UpdateHistoryMode.REPLACE)")
+                addStatement("router.navigateTo(window.location.href.removePrefix(window.location.origin), UpdateHistoryMode.REPLACE, autoPrefix = false)")
                 addStatement("")
-                addComment("For SEO, we may bake the contents of a page in at build time. However, we will")
-                addComment("overwrite them the first time we render this page with their composable, dynamic")
-                addComment("versions. Think of this as poor man's hydration :)")
-                addComment("See also: https://en.wikipedia.org/wiki/Hydration_(web_development)")
+            }.build())
+
+            addComment("For SEO, we may bake the contents of a page in at build time. However, we will")
+            addComment("overwrite them the first time we render this page with their composable, dynamic")
+            addComment("versions. Think of this as poor man's hydration :)")
+            addComment("See also: https://en.wikipedia.org/wiki/Hydration_(web_development)")
+            addCode(CodeBlock.Builder().apply {
                 addStatement("val root = document.getElementById(\"root\")!!")
                 addStatement("while (root.firstChild != null) { root.removeChild(root.firstChild!!) }")
                 addStatement("")
+            }.build())
+
+            addCode(CodeBlock.Builder().apply {
                 addStatement(
                     "AppGlobals.initialize(mapOf(${Array(appGlobals.size) { "%S to %S" }.joinToString()}))",
                     *appGlobals.flatMap { entry -> listOf(entry.key, entry.value) }.toTypedArray()


### PR DESCRIPTION
After this change, `Router.tryRoutingTo` and `Router.navigateTo` become route prefix aware. There is additional code in place to make sure we don't break old codebases (by detecting double route prefixes and falling back in that case)