### PR TITLE
Remove `StyleScope` from `CssRule`

### DIFF
--- a/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/style/CssRule.kt
+++ b/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/style/CssRule.kt
@@ -79,7 +79,7 @@ sealed class CssRule {
      *
      * For example, passing in "aria-disabled" would result in: `[aria-disabled]`
      */
-    class OfAttributeSelector(val attributeSelector: String) : NonMediaCssRule() {
+    class OfAttributeSelector(internal val attributeSelector: String) : NonMediaCssRule() {
         override fun toSelectorText() = buildSelectorText(listOf(this), emptyList(), null)
 
         operator fun plus(other: OfAttributeSelector) =
@@ -98,7 +98,7 @@ sealed class CssRule {
      *
      * For example, passing in "hover" would result in: `:hover`
      */
-    class OfPseudoClass(val pseudoClass: String) : NonMediaCssRule() {
+    class OfPseudoClass(internal val pseudoClass: String) : NonMediaCssRule() {
         override fun toSelectorText() = buildSelectorText(emptyList(), listOf(this), null)
 
         operator fun plus(other: OfPseudoClass) =
@@ -113,7 +113,7 @@ sealed class CssRule {
      *
      * For example, passing in "after" would result in: `::after`
      */
-    class OfPseudoElement(val pseudoElement: String) : NonMediaCssRule() {
+    class OfPseudoElement(internal val pseudoElement: String) : NonMediaCssRule() {
         override fun toSelectorText() = buildSelectorText(emptyList(), emptyList(), this)
     }
 
@@ -123,8 +123,8 @@ sealed class CssRule {
      */
     class CompositeOpen(
         override val mediaQuery: CSSMediaQuery?,
-        val attributeSelectors: List<OfAttributeSelector>,
-        val pseudoClasses: List<OfPseudoClass>
+        private val attributeSelectors: List<OfAttributeSelector>,
+        private val pseudoClasses: List<OfPseudoClass>
     ) : NonMediaCssRule() {
         override fun toSelectorText() = buildSelectorText(attributeSelectors, pseudoClasses, null)
 
@@ -144,9 +144,9 @@ sealed class CssRule {
      */
     class CompositeClosed(
         override val mediaQuery: CSSMediaQuery?,
-        val attributeSelectors: List<OfAttributeSelector>,
-        val pseudoClasses: List<OfPseudoClass>,
-        val pseudoElement: OfPseudoElement
+        private val attributeSelectors: List<OfAttributeSelector>,
+        private val pseudoClasses: List<OfPseudoClass>,
+        private val pseudoElement: OfPseudoElement
     ) : NonMediaCssRule() {
         override fun toSelectorText() = buildSelectorText(attributeSelectors, pseudoClasses, pseudoElement)
     }

--- a/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/style/StyleScope.kt
+++ b/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/style/StyleScope.kt
@@ -46,8 +46,9 @@ abstract class StyleScope {
         _cssModifiers.add(CssModifier(createModifier(), mediaQuery))
     }
 
-    // Note: This probably would have been an extension method except Kotlin doesn't support multiple receivers yet
-    // (here, we'd need to access both "BreakpointQueryProvider" and "StyleScope")
+    // Note: These probably would have been an extension methods except Kotlin doesn't support multiple receivers yet
+    // (here, we'd need to access both "BreakpointQueryProvider/CssRule" and "StyleScope")
+
     /**
      * Declare a style that applies within the provided breakpoint(s).
      *
@@ -69,6 +70,10 @@ abstract class StyleScope {
      */
     operator fun BreakpointQueryProvider.invoke(createModifier: () -> Modifier) {
         cssRule(toCSSMediaQuery(), createModifier)
+    }
+
+    operator fun CssRule.invoke(createModifier: () -> Modifier) {
+        cssRule(this@StyleScope, createModifier)
     }
 }
 

--- a/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/style/selectors/CssRules.kt
+++ b/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/style/selectors/CssRules.kt
@@ -13,7 +13,7 @@ import org.jetbrains.compose.web.css.*
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:any-link">:any-link</a>
  */
-val StyleScope.anyLink get() = CssRule.OfPseudoClass(this, "any-link")
+val StyleScope.anyLink get() = CssRule.OfPseudoClass("any-link")
 
 /**
  * Styles to apply to components that represent navigation links which have not yet been visited.
@@ -22,14 +22,14 @@ val StyleScope.anyLink get() = CssRule.OfPseudoClass(this, "any-link")
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:link">:link</a>
  */
-val StyleScope.link get() = CssRule.OfPseudoClass(this, "link")
+val StyleScope.link get() = CssRule.OfPseudoClass("link")
 
 /**
  * Styles to apply to elements that are targets of links in the same document.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:target">:target</a>
  */
-val StyleScope.target get() = CssRule.OfPseudoClass(this, "target")
+val StyleScope.target get() = CssRule.OfPseudoClass("target")
 
 /**
  * Styles to apply to components that represent navigation links which have previously been visited.
@@ -38,7 +38,7 @@ val StyleScope.target get() = CssRule.OfPseudoClass(this, "target")
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:visited">:visited</a>
  */
-val StyleScope.visited get() = CssRule.OfPseudoClass(this, "visited")
+val StyleScope.visited get() = CssRule.OfPseudoClass("visited")
 
 //endregion
 
@@ -51,7 +51,7 @@ val StyleScope.visited get() = CssRule.OfPseudoClass(this, "visited")
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:hover">:hover</a>
  */
-val StyleScope.hover get() = CssRule.OfPseudoClass(this, "hover")
+val StyleScope.hover get() = CssRule.OfPseudoClass("hover")
 
 /**
  * Styles to apply to components when a cursor is interacting with them.
@@ -60,28 +60,28 @@ val StyleScope.hover get() = CssRule.OfPseudoClass(this, "hover")
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:active">:active</a>
  */
-val StyleScope.active: CssRule.OfPseudoClass get() = CssRule.OfPseudoClass(this, "active")
+val StyleScope.active: CssRule.OfPseudoClass get() = CssRule.OfPseudoClass("active")
 
 /**
  * Styles to apply to components when they have focus.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:focus">:focus</a>
  */
-val StyleScope.focus get() = CssRule.OfPseudoClass(this, "focus")
+val StyleScope.focus get() = CssRule.OfPseudoClass("focus")
 
 /**
  * Styles to apply to components when they have keyboard / a11y-assisted focus.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible">:focus-visible</a>
  */
-val StyleScope.focusVisible get() = CssRule.OfPseudoClass(this, "focus-visible")
+val StyleScope.focusVisible get() = CssRule.OfPseudoClass("focus-visible")
 
 /**
  * Styles to apply to components when they or any descendants have focus.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-within">:focus-within</a>
  */
-val StyleScope.focusWithin get() = CssRule.OfPseudoClass(this, "focus-within")
+val StyleScope.focusWithin get() = CssRule.OfPseudoClass("focus-within")
 
 //endregion
 
@@ -92,84 +92,84 @@ val StyleScope.focusWithin get() = CssRule.OfPseudoClass(this, "focus-within")
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:autofill">:autofill</a>
  */
-val StyleScope.autofill get() = CssRule.OfPseudoClass(this, "autofill")
+val StyleScope.autofill get() = CssRule.OfPseudoClass("autofill")
 
 /**
  * Represents a user interface element that is in an enabled state.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:enabled">:enabled</a>
  */
-val StyleScope.enabled get() = CssRule.OfPseudoClass(this, "enabled")
+val StyleScope.enabled get() = CssRule.OfPseudoClass("enabled")
 
 /**
  * Represents a user interface element that is in a disabled state.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:disabled">:disabled</a>
  */
-val StyleScope.disabled get() = CssRule.OfPseudoClass(this, "disabled")
+val StyleScope.disabled get() = CssRule.OfPseudoClass("disabled")
 
 /**
  * Represents any element that cannot be changed by the user.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:read-only">:read-only</a>
  */
-val StyleScope.readOnly get() = CssRule.OfPseudoClass(this, "read-only")
+val StyleScope.readOnly get() = CssRule.OfPseudoClass("read-only")
 
 /**
  * Represents any element that is user-editable.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:read-write">:read-write</a>
  */
-val StyleScope.readWrite get() = CssRule.OfPseudoClass(this, "read-write")
+val StyleScope.readWrite get() = CssRule.OfPseudoClass("read-write")
 
 /**
  * Matches an input element that is displaying placeholder text.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:placeholder-shown">:placeholder-shown</a>
  */
-val StyleScope.placeholderShown get() = CssRule.OfPseudoClass(this, "placeholder-shown")
+val StyleScope.placeholderShown get() = CssRule.OfPseudoClass("placeholder-shown")
 
 /**
  * Matches one or more UI elements that are the default among a set of elements.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:default">:default</a>
  */
-val StyleScope.default get() = CssRule.OfPseudoClass(this, "default")
+val StyleScope.default get() = CssRule.OfPseudoClass("default")
 
 /**
  * Matches an element, such as checkboxes and radio buttons, that are checked or toggled to an `on` state.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:checked">:checked</a>
  */
-val StyleScope.checked get() = CssRule.OfPseudoClass(this, "checked")
+val StyleScope.checked get() = CssRule.OfPseudoClass("checked")
 
 /**
  * Matches when elements, such as checkboxes and radio buttons, are in an indeterminate state.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:indeterminate">:indeterminate</a>
  */
-val StyleScope.indeterminate get() = CssRule.OfPseudoClass(this, "indeterminate")
+val StyleScope.indeterminate get() = CssRule.OfPseudoClass("indeterminate")
 
 /**
  * Matches an element with valid contents. For example, an input element with type 'email' which contains a validly formed email address.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:valid">:valid</a>
  */
-val StyleScope.valid get() = CssRule.OfPseudoClass(this, "valid")
+val StyleScope.valid get() = CssRule.OfPseudoClass("valid")
 
 /**
  * Matches an element with invalid contents. For example, an input element with type 'email' with a name entered.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:invalid">:invalid</a>
  */
-val StyleScope.invalid get() = CssRule.OfPseudoClass(this, "invalid")
+val StyleScope.invalid get() = CssRule.OfPseudoClass("invalid")
 
 /**
  * Applies to elements with range limitations, for example a slider control, when the selected value is in the allowed range.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:in-range">:in-range</a>
  */
-val StyleScope.inRange get() = CssRule.OfPseudoClass(this, "in-range")
+val StyleScope.inRange get() = CssRule.OfPseudoClass("in-range")
 
 /**
  * Applies to elements with range limitations, for example a slider control, when the selected value is outside the
@@ -177,35 +177,35 @@ val StyleScope.inRange get() = CssRule.OfPseudoClass(this, "in-range")
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:out-of-range">:out-of-range</a>
  */
-val StyleScope.outOfRange get() = CssRule.OfPseudoClass(this, "out-of-range")
+val StyleScope.outOfRange get() = CssRule.OfPseudoClass("out-of-range")
 
 /**
  * Matches when a form element is required.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:required">:required</a>
  */
-val StyleScope.required get() = CssRule.OfPseudoClass(this, "required")
+val StyleScope.required get() = CssRule.OfPseudoClass("required")
 
 /**
  * Matches when a form element is optional.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:optional">:optional</a>
  */
-val StyleScope.optional get() = CssRule.OfPseudoClass(this, "optional")
+val StyleScope.optional get() = CssRule.OfPseudoClass("optional")
 
 /**
  * Represents an element with correct input, but only when the user has interacted with it.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:user-valid">:user-valid</a>
  */
-val StyleScope.userValid get() = CssRule.OfPseudoClass(this, "user-valid")
+val StyleScope.userValid get() = CssRule.OfPseudoClass("user-valid")
 
 /**
  * Represents an element with incorrect input, but only when the user has interacted with it.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:user-invalid">:user-invalid</a>
  */
-val StyleScope.userInvalid get() = CssRule.OfPseudoClass(this, "user-invalid")
+val StyleScope.userInvalid get() = CssRule.OfPseudoClass("user-invalid")
 
 //endregion
 
@@ -216,56 +216,56 @@ val StyleScope.userInvalid get() = CssRule.OfPseudoClass(this, "user-invalid")
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:root">:root</a>
  */
-val StyleScope.root get() = CssRule.OfPseudoClass(this, "root")
+val StyleScope.root get() = CssRule.OfPseudoClass("root")
 
 /**
  * Represents an element with no children other than white-space characters.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:empty">:empty</a>
  */
-val StyleScope.empty get() = CssRule.OfPseudoClass(this, "empty")
+val StyleScope.empty get() = CssRule.OfPseudoClass("empty")
 
 /**
  * Matches an element that is the first of its siblings.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:first-child">:first-child</a>
  */
-val StyleScope.firstChild get() = CssRule.OfPseudoClass(this, "first-child")
+val StyleScope.firstChild get() = CssRule.OfPseudoClass("first-child")
 
 /**
  * Matches an element that is the last of its siblings.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:last-child">:last-child</a>
  */
-val StyleScope.lastChild get() = CssRule.OfPseudoClass(this, "last-child")
+val StyleScope.lastChild get() = CssRule.OfPseudoClass("last-child")
 
 /**
  * Matches an element that has no siblings. For example, a list item with no other list items in that list.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:only-child">:only-child</a>
  */
-val StyleScope.onlyChild get() = CssRule.OfPseudoClass(this, "only-child")
+val StyleScope.onlyChild get() = CssRule.OfPseudoClass("only-child")
 
 /**
  * Matches an element that is the first of its siblings, and also matches a certain type selector.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:first-of-type">:first-of-type</a>
  */
-val StyleScope.firstOfType get() = CssRule.OfPseudoClass(this, "first-of-type")
+val StyleScope.firstOfType get() = CssRule.OfPseudoClass("first-of-type")
 
 /**
  * Matches an element that is the last of its siblings, and also matches a certain type selector.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:last-of-type">:last-of-type</a>
  */
-val StyleScope.lastOfType get() = CssRule.OfPseudoClass(this, "last-of-type")
+val StyleScope.lastOfType get() = CssRule.OfPseudoClass("last-of-type")
 
 /**
  * Matches an element that has no siblings of the chosen type selector.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/:only-of-type">:only-of-type</a>
  */
-val StyleScope.onlyOfType get() = CssRule.OfPseudoClass(this, "only-of-type")
+val StyleScope.onlyOfType get() = CssRule.OfPseudoClass("only-of-type")
 
 //endregion
 
@@ -278,35 +278,35 @@ val StyleScope.onlyOfType get() = CssRule.OfPseudoClass(this, "only-of-type")
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/::before">::before</a>
  */
-val StyleScope.before get() = CssRule.OfPseudoElement(this, "before")
+val StyleScope.before get() = CssRule.OfPseudoElement("before")
 
 /**
  * Styles to apply to a virtual element that is created after the last element in some container.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/::after">::after</a>
  */
-val StyleScope.after get() = CssRule.OfPseudoElement(this, "after")
+val StyleScope.after get() = CssRule.OfPseudoElement("after")
 
 /**
  * Styles to apply to the selected part of a document.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/::selection">::selection</a>
  */
-val StyleScope.selection get() = CssRule.OfPseudoElement(this, "selection")
+val StyleScope.selection get() = CssRule.OfPseudoElement("selection")
 
 /**
  * Styles to apply to the first letter in a block of text.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/::first-letter">::first-letter</a>
  */
-val StyleScope.firstLetter get() = CssRule.OfPseudoElement(this, "first-letter")
+val StyleScope.firstLetter get() = CssRule.OfPseudoElement("first-letter")
 
 /**
  * Styles to apply to the first line in a block of text.
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/::first-line">::first-line</a>
  */
-val StyleScope.firstLine get() = CssRule.OfPseudoElement(this, "first-line")
+val StyleScope.firstLine get() = CssRule.OfPseudoElement("first-line")
 
 /**
  * Matches the placeholder text within an input element that is displaying placeholder text.
@@ -315,7 +315,7 @@ val StyleScope.firstLine get() = CssRule.OfPseudoElement(this, "first-line")
  *
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/::placeholder">::placeholder</a>
  */
-val StyleScope.placeholder get() = CssRule.OfPseudoElement(this, "placeholder")
+val StyleScope.placeholder get() = CssRule.OfPseudoElement("placeholder")
 
 //endregion
 
@@ -324,13 +324,13 @@ val StyleScope.placeholder get() = CssRule.OfPseudoElement(this, "placeholder")
 /**
  * Used to indicate styles which should only be applied when the page is being printed.
  */
-val StyleScope.mediaPrint get() = CssRule.OfMedia(this, CSSMediaQuery.MediaType(CSSMediaQuery.MediaType.Enum.Print))
+val StyleScope.mediaPrint get() = CssRule.OfMedia(CSSMediaQuery.MediaType(CSSMediaQuery.MediaType.Enum.Print))
 
 //endregion
 
 // region Functional pseudo classes
 
-fun StyleScope.not(vararg params: CssRule.NonMediaCssRule) = CssRule.OfFunctionalPseudoClass(this, "not", *params)
+fun StyleScope.not(vararg params: CssRule.NonMediaCssRule) = CssRule.OfFunctionalPseudoClass("not", *params)
 
 //endregion
 
@@ -343,7 +343,7 @@ fun StyleScope.not(vararg params: CssRule.NonMediaCssRule) = CssRule.OfFunctiona
  * the HTML version; for example, some elements don't support `disabled` and also `disabled` elements don't fire
  * mouse events, which can be useful e.g. when implementing tooltips.
  */
-val StyleScope.ariaDisabled get() = CssRule.OfAttributeSelector(this, """aria-disabled="true"""")
+val StyleScope.ariaDisabled get() = CssRule.OfAttributeSelector("""aria-disabled="true"""")
 
 /**
  * A way to select elements that have been tagged with an `aria-invalid` attribute.
@@ -352,7 +352,7 @@ val StyleScope.ariaDisabled get() = CssRule.OfAttributeSelector(this, """aria-di
  * widget supports a general invalidation algorithm (like an email type input with an invalid email address), but the
  * `ariaInvalid` version can be used to support custom invalidation strategies.
  */
-val StyleScope.ariaInvalid get() = CssRule.OfAttributeSelector(this, """aria-invalid="true"""")
+val StyleScope.ariaInvalid get() = CssRule.OfAttributeSelector("""aria-invalid="true"""")
 
 /**
  * A way to select elements that have been tagged with an `aria-required` attribute.
@@ -361,6 +361,6 @@ val StyleScope.ariaInvalid get() = CssRule.OfAttributeSelector(this, """aria-inv
  * using elements that don't support the `required` attribute, like elements created from divs, as a way to communicate
  * their required state to accessibility readers.
  */
-val StyleScope.ariaRequired get() = CssRule.OfAttributeSelector(this, """aria-required="true"""")
+val StyleScope.ariaRequired get() = CssRule.OfAttributeSelector("""aria-required="true"""")
 
 //endregion


### PR DESCRIPTION
Instead, we adopt a design similar to breakpoints/breakpoint ranges.