### PR TITLE
Improve Callout widget spacing

### DIFF
--- a/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/display/Callout.kt
+++ b/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/display/Callout.kt
@@ -161,9 +161,15 @@ val CalloutStyle = CssStyle<CalloutKind> {
     }
 }
 
-// Markdown generates blockquote content wrapped in a <p> tag, which adds weird spacing that we don't want.
-private fun CssStyleScope.markdownParagraphHack() {
-    cssRule(" >.callout-body>p:last-child") {
+// If the callout content is wrapped in a <p> tag (which is the default behavior for Markdown content), we do not want
+// paragraph spacing to interfere with the callout layout.
+// An alternative would be to embrace the <p> spacing in our design, but this would lead to poor results for sites which
+// explicitly remove margin from their <p> tags as part of a CSS reset.
+private fun CssStyleScope.removeEdgeParagraphSpacing() {
+    cssRule(" > .callout-body > p:first-child") {
+        Modifier.marginBlock { start(0.px) }
+    }
+    cssRule(" > .callout-body > p:last-child") {
         Modifier.marginBlock { end(0.px) }
     }
 }
@@ -182,7 +188,7 @@ val LeftBorderedCalloutVariant = CalloutStyle.addVariant {
             .margin { bottom(1.cssRem) }
     }
 
-    markdownParagraphHack()
+    removeEdgeParagraphSpacing()
 }
 
 // Style from https://just-the-docs.com/docs/ui-components/callouts/
@@ -202,10 +208,10 @@ val LeftBorderedFilledCalloutVariant = CalloutStyle.addVariant {
     cssRule(" >.callout-title") {
         Modifier
             .color(CalloutVars.Color.value())
-            .margin { bottom(0.5.cssRem) }
+            .margin { bottom(0.75.cssRem) }
     }
 
-    markdownParagraphHack()
+    removeEdgeParagraphSpacing()
 }
 
 
@@ -231,7 +237,7 @@ val OutlinedCalloutVariant = CalloutStyle.addVariant {
         Modifier.padding(0.5.cssRem, 0.75.cssRem)
     }
 
-    markdownParagraphHack()
+    removeEdgeParagraphSpacing()
 }
 
 /**

--- a/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/display/Callout.kt
+++ b/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/display/Callout.kt
@@ -13,7 +13,6 @@ import com.varabyte.kobweb.compose.ui.graphics.Color
 import com.varabyte.kobweb.compose.ui.graphics.Colors
 import com.varabyte.kobweb.compose.ui.modifiers.*
 import com.varabyte.kobweb.compose.ui.toAttrs
-import com.varabyte.kobweb.silk.components.icons.CloseIcon
 import com.varabyte.kobweb.silk.components.icons.ExclaimIcon
 import com.varabyte.kobweb.silk.components.icons.InfoIcon
 import com.varabyte.kobweb.silk.components.icons.LightbulbIcon
@@ -42,6 +41,7 @@ object CalloutVars {
     val BackgroundColor by StyleVariable<CSSColorValue>(prefix = "silk")
     val TitleFontSize by StyleVariable<CSSLengthNumericValue>(prefix = "silk")
     val TitleGap by StyleVariable<CSSLengthNumericValue>(prefix = "silk", defaultFallback = 0.5.cssRem)
+    val TitleLineHeight by StyleVariable<Number>(prefix = "silk", defaultFallback = 1)
 }
 
 class CalloutType(
@@ -157,6 +157,7 @@ val CalloutStyle = CssStyle<CalloutKind> {
             .fontWeight(FontWeight.Medium)
             .fontSize(CalloutVars.TitleFontSize.value())
             .gap(CalloutVars.TitleGap.value())
+            .lineHeight(CalloutVars.TitleLineHeight.value())
     }
 }
 
@@ -201,7 +202,7 @@ val LeftBorderedFilledCalloutVariant = CalloutStyle.addVariant {
     cssRule(" >.callout-title") {
         Modifier
             .color(CalloutVars.Color.value())
-            .margin { bottom(0.25.cssRem) }
+            .margin { bottom(0.5.cssRem) }
     }
 
     markdownParagraphHack()
@@ -219,7 +220,7 @@ val OutlinedCalloutVariant = CalloutStyle.addVariant {
     cssRule(" >.callout-title") {
         Modifier
             .backgroundColor(CalloutVars.BackgroundColor.value())
-            .padding(0.5.cssRem, 0.75.cssRem)
+            .padding(0.75.cssRem, 0.75.cssRem)
     }
 
     cssRule(" .callout-icon") {


### PR DESCRIPTION
This removes unwanted spacing from our docs site, which exposed some cases that were not being properly handled.