### PR TITLE
Make invalid CssStyle error message lazy

### DIFF
--- a/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/init/SilkStylesheet.kt
+++ b/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/init/SilkStylesheet.kt
@@ -163,10 +163,9 @@ internal object SilkStylesheetInstance : SilkStylesheet {
         this.invoke(simpleStyleScope)
 
         simpleStyleScope.cssModifiers.forEach { cssModifier ->
-            cssModifier.assertNoAttributes(
-                selectorName,
-                extraContext = "Please search your `@InitSilk` code for a line like `ctx.stylesheet.registerStyle(\"$selectorName\")` and remove the offending attribute(s)."
-            )
+            cssModifier.assertNoAttributes(selectorName) {
+                "Please search your `@InitSilk` code for a line like `ctx.stylesheet.registerStyle(\"$selectorName\")` and remove the offending attribute(s)."
+            }
         }
     }
 

--- a/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/style/CssStyle.kt
+++ b/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/style/CssStyle.kt
@@ -233,9 +233,8 @@ abstract class CssStyle<K : CssKind> internal constructor(
         layer: String?
     ): Map<CssModifier.Key, CssModifier> {
         return this.onEach { (_, cssModifier) ->
-            cssModifier.assertNoAttributes(
-                selectorName,
-                extraContext = buildString {
+            cssModifier.assertNoAttributes(selectorName) {
+                buildString {
                     val styleDeclaration = when {
                         layer == SilkLayer.COMPONENT_VARIANTS.layerName -> "val SomeExampleVariant = ExampleStyle.addVariant"
                         layer == SilkLayer.COMPONENT_STYLES.layerName -> "val ExampleStyle = CssStyle<ExampleKind>"
@@ -264,7 +263,7 @@ abstract class CssStyle<K : CssKind> internal constructor(
                         """.trimMargin()
                     )
                 }
-            )
+            }
         }
     }
 

--- a/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/style/StyleScope.kt
+++ b/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/style/StyleScope.kt
@@ -170,7 +170,7 @@ internal class CssModifier(
     val key get() = Key(mediaQuery?.toString(), suffix)
 }
 
-internal fun CssModifier.assertNoAttributes(selectorName: String, extraContext: String) {
+internal fun CssModifier.assertNoAttributes(selectorName: String, lazyExtraContext: () -> String) {
     val attrsScope = ComparableAttrsScope<Element>()
     this.modifier.toAttrs<AttrsScope<Element>>().invoke(attrsScope)
 
@@ -188,6 +188,6 @@ internal fun CssModifier.assertNoAttributes(selectorName: String, extraContext: 
         appendLine("\"")
         appendLine("\tAttribute(s): ${attrsScope.attributes.keys.joinToString(", ") { "\"$it\"" }}")
         appendLine()
-        appendLine(extraContext)
+        appendLine(lazyExtraContext())
     })
 }


### PR DESCRIPTION
This avoids an unnecessary performance penalty from `trimMargin()` calls that never get used.