### PR TITLE
Fix fallback styles for browsers that do not support `@scope`

### DIFF
--- a/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/style/CssStyle.kt
+++ b/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/style/CssStyle.kt
@@ -368,12 +368,6 @@ abstract class CssStyle<K : CssKind> internal constructor(
         val lightStyleSheet = StyleSheet()
         val darkStylesSheet = StyleSheet()
 
-        fun registerSuffixedStyle(group: StyleGroup) = when (ColorModeStrategy.current) {
-            ColorModeStrategy.SCOPE -> false
-            ColorModeStrategy.SUFFIX -> true
-            ColorModeStrategy.BOTH -> group !is StyleGroup.ColorAgnostic // SCOPE mode registers these without `@scope` anyway
-        }
-
         StyleGroup.from(lightModifiers[CssModifier.BaseKey]?.modifier, darkModifiers[CssModifier.BaseKey]?.modifier)
             ?.let { group ->
                 if (ColorModeStrategy.current.useScope) {
@@ -385,7 +379,7 @@ abstract class CssStyle<K : CssKind> internal constructor(
                         }
                     }
                 }
-                if (registerSuffixedStyle(group)) {
+                if (ColorModeStrategy.current.useSuffix) {
                     withSuffixedSelectorName(selector, group) { name, styles ->
                         if (styles.isNotEmpty()) {
                             classNames.add(name)
@@ -412,7 +406,7 @@ abstract class CssStyle<K : CssKind> internal constructor(
                     }
                 }
             }
-            if (registerSuffixedStyle(group)) {
+            if (ColorModeStrategy.current.useSuffix) {
                 withSuffixedSelectorName(selector, group) { name, styles ->
                     if (styles.isNotEmpty()) {
                         classNames.add(name)


### PR DESCRIPTION
In 1462883ee50289ab68ea466ca66875d0803b35f3, we made it so that color mode agnostic styles used `@scope`, but did not adjust the compatibility mode used during export to also export these styles without `@scope`.