### PR TITLE
Add `HTMLElement`-based validation to CSS tests

### DIFF
--- a/frontend/compose-html-ext/src/jsMain/kotlin/com/varabyte/kobweb/compose/css/Alignment.kt
+++ b/frontend/compose-html-ext/src/jsMain/kotlin/com/varabyte/kobweb/compose/css/Alignment.kt
@@ -80,7 +80,8 @@ sealed interface AlignContent : StylePropertyValue {
         // Baseline
         val Baseline get() = (null as? BaselineSet?).toValue().unsafeCast<AlignContent>()
         val FirstBaseline get() = BaselineSet.First.toValue().unsafeCast<AlignContent>()
-        val LastBaseline get() = BaselineSet.Last.toValue().unsafeCast<AlignContent>()
+        // Not widely supported: https://caniuse.com/mdn-css_properties_align-content_flex_context_last_baseline
+        // val LastBaseline get() = BaselineSet.Last.toValue().unsafeCast<AlignContent>()
 
         // Overflow
         fun Safe(position: AlignContentPosition) = OverflowStrategy.Safe.toValue(position).unsafeCast<AlignContent>()
@@ -289,7 +290,7 @@ sealed interface JustifySelf : StylePropertyValue {
         val Normal get() = "normal".unsafeCast<JustifySelf>()
         val Stretch get() = "stretch".unsafeCast<JustifySelf>()
 
-        // Positional  
+        // Positional
         val Center get() = "center".unsafeCast<JustifySelfPosition>()
         val Start get() = "start".unsafeCast<JustifySelfPosition>()
         val End get() = "end".unsafeCast<JustifySelfPosition>()

--- a/frontend/compose-html-ext/src/jsMain/kotlin/com/varabyte/kobweb/compose/css/Background.kt
+++ b/frontend/compose-html-ext/src/jsMain/kotlin/com/varabyte/kobweb/compose/css/Background.kt
@@ -26,25 +26,6 @@ sealed interface BackgroundBlendMode : StylePropertyValue {
 
     companion object : CssBlendModeValues<Listable>, CssGlobalValues<BackgroundBlendMode> {
         fun list(vararg blendModes: Listable): BackgroundBlendMode = blendModes.joinToString().unsafeCast<BackgroundBlendMode>()
-
-        override val Normal get() = "normal".unsafeCast<Listable>()
-        override val Multiply get() = "multiply".unsafeCast<Listable>()
-        override val Screen get() = "screen".unsafeCast<Listable>()
-        override val Overlay get() = "overlay".unsafeCast<Listable>()
-        override val Darken get() = "darken".unsafeCast<Listable>()
-        override val Lighten get() = "lighten".unsafeCast<Listable>()
-        override val ColorDodge get() = "color-dodge".unsafeCast<Listable>()
-        override val ColorBurn get() = "color-burn".unsafeCast<Listable>()
-        override val HardLight get() = "hard-light".unsafeCast<Listable>()
-        override val SoftLight get() = "soft-light".unsafeCast<Listable>()
-        override val Difference get() = "difference".unsafeCast<Listable>()
-        override val Exclusion get() = "exclusion".unsafeCast<Listable>()
-        override val Hue get() = "hue".unsafeCast<Listable>()
-        override val Saturation get() = "saturation".unsafeCast<Listable>()
-        override val Color get() = "color".unsafeCast<Listable>()
-        override val Luminosity get() = "luminosity".unsafeCast<Listable>()
-        override val PlusDarker get() = "plus-darker".unsafeCast<Listable>()
-        override val PlusLighter get() = "plus-lighter".unsafeCast<Listable>()
     }
 }
 

--- a/frontend/compose-html-ext/src/jsMain/kotlin/com/varabyte/kobweb/compose/css/Media.kt
+++ b/frontend/compose-html-ext/src/jsMain/kotlin/com/varabyte/kobweb/compose/css/Media.kt
@@ -3,48 +3,33 @@ package com.varabyte.kobweb.compose.css
 import org.jetbrains.compose.web.css.*
 
 interface CssBlendModeValues<T: StylePropertyValue> {
-    val Normal: T
-    val Multiply: T
-    val Screen: T
-    val Overlay: T
-    val Darken: T
-    val Lighten: T
-    val ColorDodge: T
-    val ColorBurn: T
-    val HardLight: T
-    val SoftLight: T
-    val Difference: T
-    val Exclusion: T
-    val Hue: T
-    val Saturation: T
-    val Color: T
-    val Luminosity: T
-    val PlusDarker: T
-    val PlusLighter: T
+    val Normal get() = "normal".unsafeCast<T>()
+    val Multiply get() = "multiply".unsafeCast<T>()
+    val Screen get() = "screen".unsafeCast<T>()
+    val Overlay get() = "overlay".unsafeCast<T>()
+    val Darken get() = "darken".unsafeCast<T>()
+    val Lighten get() = "lighten".unsafeCast<T>()
+    val ColorDodge get() = "color-dodge".unsafeCast<T>()
+    val ColorBurn get() = "color-burn".unsafeCast<T>()
+    val HardLight get() = "hard-light".unsafeCast<T>()
+    val SoftLight get() = "soft-light".unsafeCast<T>()
+    val Difference get() = "difference".unsafeCast<T>()
+    val Exclusion get() = "exclusion".unsafeCast<T>()
+    val Hue get() = "hue".unsafeCast<T>()
+    val Saturation get() = "saturation".unsafeCast<T>()
+    val Color get() = "color".unsafeCast<T>()
+    val Luminosity get() = "luminosity".unsafeCast<T>()
+    // Not widely supported: https://caniuse.com/mdn-css_properties_mix-blend-mode_plus-darker
+    // val PlusDarker get() = "plus-darker".unsafeCast<T>()
+    // Not widely supported in `background-blend-mode` (added below in `MixBlendMode`):
+    // https://wpt.fyi/results/css/compositing/background-blending?q=plus-lighter
+    // val PlusLighter get() = "plus-lighter".unsafeCast<T>()
 }
 
 // See: https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode
 sealed interface MixBlendMode : StylePropertyValue {
     companion object : CssBlendModeValues<MixBlendMode>, CssGlobalValues<MixBlendMode> {
-        // Keywords
-        override val Normal get() = "normal".unsafeCast<MixBlendMode>()
-        override val Multiply get() = "multiply".unsafeCast<MixBlendMode>()
-        override val Screen get() = "screen".unsafeCast<MixBlendMode>()
-        override val Overlay get() = "overlay".unsafeCast<MixBlendMode>()
-        override val Darken get() = "darken".unsafeCast<MixBlendMode>()
-        override val Lighten get() = "lighten".unsafeCast<MixBlendMode>()
-        override val ColorDodge get() = "color-dodge".unsafeCast<MixBlendMode>()
-        override val ColorBurn get() = "color-burn".unsafeCast<MixBlendMode>()
-        override val HardLight get() = "hard-light".unsafeCast<MixBlendMode>()
-        override val SoftLight get() = "soft-light".unsafeCast<MixBlendMode>()
-        override val Difference get() = "difference".unsafeCast<MixBlendMode>()
-        override val Exclusion get() = "exclusion".unsafeCast<MixBlendMode>()
-        override val Hue get() = "hue".unsafeCast<MixBlendMode>()
-        override val Saturation get() = "saturation".unsafeCast<MixBlendMode>()
-        override val Color get() = "color".unsafeCast<MixBlendMode>()
-        override val Luminosity get() = "luminosity".unsafeCast<MixBlendMode>()
-        override val PlusDarker get() = "plus-darker".unsafeCast<MixBlendMode>()
-        override val PlusLighter get() = "plus-lighter".unsafeCast<MixBlendMode>()
+        val PlusLighter get() = "plus-lighter".unsafeCast<MixBlendMode>()
     }
 }
 

--- a/frontend/compose-html-ext/src/jsMain/kotlin/com/varabyte/kobweb/compose/css/Text.kt
+++ b/frontend/compose-html-ext/src/jsMain/kotlin/com/varabyte/kobweb/compose/css/Text.kt
@@ -56,7 +56,8 @@ sealed interface TextAlign : StylePropertyValue {
         // val JustifyAll get() = "justify-all".unsafeCast<TextAlign>()
         val Start get() = "start".unsafeCast<TextAlign>()
         val End get() = "end".unsafeCast<TextAlign>()
-        val MatchParent get() = "match-parent".unsafeCast<TextAlign>()
+        // Not widely supported (unprefixed): https://caniuse.com/mdn-css_properties_text-align_match-parent
+        // val MatchParent get() = "match-parent".unsafeCast<TextAlign>()
     }
 }
 

--- a/frontend/compose-html-ext/src/jsTest/kotlin/com/varabyte/kobweb/compose/css/CssStylePropertyTests.kt
+++ b/frontend/compose-html-ext/src/jsTest/kotlin/com/varabyte/kobweb/compose/css/CssStylePropertyTests.kt
@@ -14,6 +14,16 @@ import org.w3c.dom.HTMLElement
 import kotlin.test.Test
 
 class CssStylePropertyTests {
+    /**
+     * Apply a style block to a temporary HTML element and return the inline style of the element, in the form
+     * `key: value; key2: value2;`.
+     *
+     * The exact text of the values may be altered by the browser's internal normalization
+     * (e.g. `property("margin", "10px 10px")` becomes `margin: 10px;`).
+     *
+     * This is useful for testing that the browser recognizes a style as valid CSS, because an invalid style will not
+     * get applied and thus output an empty string.
+     */
     private fun styleToTextOnHtmlElement(block: StyleScope.() -> Unit): String {
         val element = document.createElement("div").unsafeCast<HTMLElement>()
         object : StyleScope {
@@ -28,8 +38,11 @@ class CssStylePropertyTests {
         return element.style.cssText
     }
 
-    // Convert all properties in a style to the String that would ultimately get put into an HTML style attribute.
-    // In other words, key / values will be split by a ':' and multiple properties by a ';'
+    /**
+     * Convert all properties in a style to the String that would ultimately get put into an HTML style attribute.
+     *
+     * In other words, key / values will be split by a ':' and multiple properties by a ';'.
+     */
     private fun styleToText(block: StyleScope.() -> Unit): String {
         // We don't care about comparing -- but it's an easy way to construct a style scope, as Compose HTML doesn't
         // give us an easy way otherwise.
@@ -37,8 +50,8 @@ class CssStylePropertyTests {
         block.invoke(styleScope)
 
         return styleScope.properties.entries.joinToString("; ") { (key, value) -> "$key: $value" }.also {
-            // Check that the browser applied the style to an HTML element, meaning it recognizes it as valid CSS
-            // We don't match on the exact string as the browser may reformat it
+            // We don't match on the exact string as the browser may reformat it, so we just check that the browser did
+            // not reject the style.
             assertWithMessage("Browser should recognize style `$it`")
                 .that(styleToTextOnHtmlElement(block))
                 .isNotBlank()


### PR DESCRIPTION
Also remove a few remaining not widely supported values.