### PR TITLE
Preserve property order and repeated declarations in `ComparableStyleScope`

### DIFF
--- a/frontend/compose-html-ext/src/jsMain/kotlin/com/varabyte/kobweb/compose/css/ComparableStyleScope.kt
+++ b/frontend/compose-html-ext/src/jsMain/kotlin/com/varabyte/kobweb/compose/css/ComparableStyleScope.kt
@@ -2,17 +2,23 @@ package com.varabyte.kobweb.compose.css
 
 import org.jetbrains.compose.web.css.*
 
+// We don't reuse JB's StylePropertyDeclaration so that [value] is a String and thus equality is well-defined.
+/** Represents a CSS property and the value it is set to, e.g. `("width", "10px")`. */
+data class CssPropertyDeclaration(val name: String, val value: String)
+
 // We need our own implementation of StyleScope, so we can both test equality and pull values out of it later
 class ComparableStyleScope : StyleScope {
-    val properties = mutableMapOf<String, String>()
-    val variables = mutableMapOf<String, String>()
+    private val _properties = mutableListOf<CssPropertyDeclaration>()
+    val properties: List<CssPropertyDeclaration> = _properties
+    private val _variables = mutableListOf<CssPropertyDeclaration>()
+    val variables: List<CssPropertyDeclaration> = _variables
 
     override fun property(propertyName: String, value: StylePropertyValue) {
-        properties[propertyName] = value.toString()
+        _properties.add(CssPropertyDeclaration(propertyName, value.toString()))
     }
 
     override fun variable(variableName: String, value: StylePropertyValue) {
-        variables[variableName] = value.toString()
+        _variables.add(CssPropertyDeclaration(variableName, value.toString()))
     }
 
     override fun equals(other: Any?): Boolean {

--- a/frontend/compose-html-ext/src/jsTest/kotlin/com/varabyte/kobweb/compose/css/CssStylePropertyTests.kt
+++ b/frontend/compose-html-ext/src/jsTest/kotlin/com/varabyte/kobweb/compose/css/CssStylePropertyTests.kt
@@ -49,7 +49,7 @@ class CssStylePropertyTests {
         val styleScope = ComparableStyleScope()
         block.invoke(styleScope)
 
-        return styleScope.properties.entries.joinToString("; ") { (key, value) -> "$key: $value" }.also {
+        return styleScope.properties.joinToString("; ") { "${it.name}: ${it.value}" }.also {
             // We don't match on the exact string as the browser may reformat it, so we just check that the browser did
             // not reject the style.
             assertWithMessage("Browser should recognize style `$it`")

--- a/frontend/kobweb-compose/src/jsTest/kotlin/com/varabyte/kobweb/compose/ui/ModifierTest.kt
+++ b/frontend/kobweb-compose/src/jsTest/kotlin/com/varabyte/kobweb/compose/ui/ModifierTest.kt
@@ -21,11 +21,23 @@ class ModifierTest {
         assertThat(Modifier.width(100.px)).isNotEqualTo(Modifier.width(100.px).height(200.px))
         assertThat(Modifier.id("id1").width(100.px).height(200.px)).isNotEqualTo(Modifier.id("id2").width(100.px).height(200.px))
 
-        // Order is important
-        // NOTE: In theory, we might revisit this later. Compose HTML doesn't care about ordering so maybe we shouldn't
-        // require it for equality testing. However, in practice, it's easier to implement this way, and it's not likely
-        // that users will pass in modifiers of one order in one recomposition step and then have the same properties in
-        // a different order in a followup step.
+        // Order is important (for CSS properties)
+        // Setting a longhand property after a shorthand property only overrides the specific longhand, but setting a
+        // shorthand property after a longhand property overrides all the longhand properties.
+        assertThat(Modifier.margin { top(50.px) }.margin(10.px)).isNotEqualTo(
+            Modifier.margin(10.px).margin { top(50.px) })
+        // A property may be set multiple times, in which case all values must match for equality to hold.
+        // This is important as CSS may apply an earlier value if a later value is invalid.
+        assertThat(Modifier.width(100.px).width(50.px)).isEqualTo(Modifier.width(100.px).width(50.px))
+        assertThat(Modifier.width(100.px).width(50.px)).isNotEqualTo(Modifier.width(25.px).width(50.px))
+        // For many properties, CSS does not care about order, but for consistency our implementation always does.
         assertThat(Modifier.width(100.px).height(200.px)).isNotEqualTo(Modifier.height(200.px).width(100.px))
+
+        // Order is important (for HTML attributes)
+        // NOTE: In theory, we might revisit this later (ONLY for attributes, NOT for CSS properties). HTML doesn't care
+        // about attribute ordering, so maybe we shouldn't require it for equality testing. However, in practice, it's
+        // easier to implement this way, and it's not likely that users will pass in modifiers of one order in one
+        // recomposition step and then have the same attributes in a different order in a followup step.
+        assertThat(Modifier.id("id").title("title")).isNotEqualTo(Modifier.title("title").id("id"))
     }
 }

--- a/frontend/kobweb-compose/src/jsTest/kotlin/com/varabyte/kobweb/compose/ui/modifiers/StyleModifierTests.kt
+++ b/frontend/kobweb-compose/src/jsTest/kotlin/com/varabyte/kobweb/compose/ui/modifiers/StyleModifierTests.kt
@@ -20,7 +20,7 @@ class StyleModifierTests {
         val modifier = produceModifier()
         modifier.toStyles().invoke(styleScope)
 
-        return styleScope.properties.entries.joinToString("; ") { (key, value) -> "$key: $value" }
+        return styleScope.properties.joinToString("; ") { "${it.name}: ${it.value}" }
     }
 
     @Test

--- a/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/style/CssStyle.kt
+++ b/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/style/CssStyle.kt
@@ -185,8 +185,8 @@ abstract class CssStyle<K : CssKind> internal constructor(
         styles: ComparableStyleScope
     ) {
         cssRule style {
-            styles.properties.forEach { entry -> property(entry.key, entry.value) }
-            styles.variables.forEach { entry -> variable(entry.key, entry.value) }
+            styles.properties.forEach { entry -> property(entry.name, entry.value) }
+            styles.variables.forEach { entry -> variable(entry.name, entry.value) }
         }
     }
 


### PR DESCRIPTION
This fixes an issue where the style
```kt
val SomeStyle = CssStyle.base { Modifier.margin(10.vw).margin(10.dvw) }
```
would be registered as `.some { margin: 10dvw; }`, ignoring the fallback declaration and breaking styling for older browsers that do not support `dvw`.

This also brings the behavior of `CssStyle` in line with inline `Modifier` styles, which already preserved repeated styles.