### PR TITLE
Router: treat //example.com as an external link

### DIFF
--- a/frontend/kobweb-core/src/jsMain/kotlin/com/varabyte/kobweb/navigation/Router.kt
+++ b/frontend/kobweb-core/src/jsMain/kotlin/com/varabyte/kobweb/navigation/Router.kt
@@ -437,7 +437,7 @@ class Router {
         updateHistoryMode: UpdateHistoryMode = UpdateHistoryMode.PUSH,
         openLinkStrategy: OpenLinkStrategy = OpenLinkStrategy.IN_PLACE,
     ): Boolean {
-        if (pathQueryAndFragment.contains("://")) return false
+        if (pathQueryAndFragment.includesHost()) return false
 
         @Suppress("NAME_SHADOWING") // Intentionally transformed
         var pathQueryAndFragment = BasePath.prependTo(pathQueryAndFragment)
@@ -592,12 +592,28 @@ class Router {
             )
         ) {
             window.open(pathQueryAndFragment,
-                if (pathQueryAndFragment.startsWith(window.origin)) {
+                if (pathQueryAndFragment.resolvesToSameOrigin()) {
                     openInternalLinksStrategy
                 } else {
                     openExternalLinksStrategy
                 }
             )
         }
+    }
+
+    /**
+     * Check whether a link includes the domain like //example.com/page or https://example.com/page
+     */
+    private fun String.includesHost(): Boolean =
+        this.contains("://")
+            || this.startsWith("//")
+
+    /**
+     * Check whether a link points to the same origin as the current page.
+     */
+    private fun String.resolvesToSameOrigin(): Boolean {
+        val resolvedUrl = URL(this, window.location.href)
+
+        return resolvedUrl.origin == window.location.origin
     }
 }


### PR DESCRIPTION
A link like `<a href="//example.com">` means to open the target in the current procol scheme, such as http or https.

Until this change the Router and Link component treated such a target as an internal link, dispatching to the current origin rather than the external domain.

Example: linking to //example.com/page from
https://example.org used to result in
https://example.org/example.com/page

With this change it will result in https://example.com/page