### PR TITLE
Delay resolving some Gradle project properties until execution time

### DIFF
--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/KobwebApplicationPlugin.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/KobwebApplicationPlugin.kt
@@ -105,11 +105,12 @@ class KobwebApplicationPlugin @Inject constructor(
 
         val env =
             project.findProperty("kobwebEnv")?.let { ServerEnvironment.valueOf(it.toString()) } ?: ServerEnvironment.DEV
-        val runLayout =
-            project.findProperty("kobwebRunLayout")?.let { SiteLayout.valueOf(it.toString()) } ?: SiteLayout.FULLSTACK
-        val exportLayout =
-            project.findProperty("kobwebExportLayout")?.let { SiteLayout.valueOf(it.toString()) }
-                ?: SiteLayout.FULLSTACK
+        val runLayout = project.providers.gradleProperty("kobwebRunLayout")
+            .map { SiteLayout.valueOf(it) }
+            .orElse(SiteLayout.FULLSTACK)
+        val exportLayout = project.providers.gradleProperty("kobwebExportLayout")
+            .map { SiteLayout.valueOf(it) }
+            .orElse(SiteLayout.FULLSTACK)
 
         project.extra["kobwebBuildTarget"] =
             project.findProperty("kobwebBuildTarget")?.let { BuildTarget.valueOf(it.toString()) }
@@ -130,7 +131,9 @@ class KobwebApplicationPlugin @Inject constructor(
 
         val kobwebUnpackServerJarTask = project.tasks.register<KobwebUnpackServerJarTask>("kobwebUnpackServerJar")
         val kobwebCreateServerScriptsTask = project.tasks
-            .register<KobwebCreateServerScriptsTask>("kobwebCreateServerScripts", exportLayout)
+            .register<KobwebCreateServerScriptsTask>("kobwebCreateServerScripts") {
+                siteLayout.set(exportLayout)
+            }
 
         val kobwebStartTask = run {
             val reuseServer = project.findProperty("kobwebReuseServer")?.toString()?.toBoolean() ?: true

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebCreateServerScriptsTask.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebCreateServerScriptsTask.kt
@@ -6,16 +6,19 @@ import com.varabyte.kobweb.gradle.application.util.getServerJar
 import com.varabyte.kobweb.gradle.core.tasks.KobwebTask
 import com.varabyte.kobweb.server.api.ServerEnvironment
 import com.varabyte.kobweb.server.api.SiteLayout
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
-import javax.inject.Inject
 
 /**
  * A simple task for creating scripts which can be used to run the Kobweb server in production mode.
  */
-abstract class KobwebCreateServerScriptsTask @Inject constructor(@get:Input val siteLayout: SiteLayout) :
+abstract class KobwebCreateServerScriptsTask :
     KobwebTask("Create scripts which can be used to start the Kobweb server in production mode") {
+    @get:Input
+    abstract val siteLayout: Property<SiteLayout>
+
     @OutputFile
     fun getServerStartShellScript() =
         kobwebApplication.kobwebFolder.path.resolve(KOBWEB_SERVER_START_SHELL_SCRIPT).toFile()
@@ -27,7 +30,7 @@ abstract class KobwebCreateServerScriptsTask @Inject constructor(@get:Input val 
     fun execute() {
         val javaArgs = listOf(
             ServerEnvironment.PROD.toSystemPropertyParam(),
-            siteLayout.toSystemPropertyParam(),
+            siteLayout.get().toSystemPropertyParam(),
             "-Dio.ktor.development=false",
             "-jar",
             kobwebApplication.kobwebFolder.getServerJar().absolutePath.let {

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebExportTask.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebExportTask.kt
@@ -19,6 +19,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
@@ -51,7 +52,7 @@ class KobwebExportConfInputs(
 abstract class KobwebExportTask @Inject constructor(
     private val exportBlock: AppBlock.ExportBlock,
     @get:Nested val confInputs: KobwebExportConfInputs,
-    @get:Input val siteLayout: SiteLayout,
+    @get:Input val siteLayout: Provider<SiteLayout>,
 ) : KobwebTask("Export the Kobweb project into a static site") {
     @get:InputFile
     abstract val appFrontendDataFile: RegularFileProperty
@@ -174,6 +175,7 @@ abstract class KobwebExportTask @Inject constructor(
 
     @TaskAction
     fun execute() {
+        val siteLayout = siteLayout.get()
         // Sever should be running since "kobwebStart" is a prerequisite for this task
         val port = ServerStateFile(kobwebApplication.kobwebFolder).content!!.port
 

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebStartTask.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebStartTask.kt
@@ -12,6 +12,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.TaskAction
@@ -29,7 +30,7 @@ import javax.inject.Inject
 abstract class KobwebStartTask @Inject constructor(
     private val remoteDebuggingBlock: AppBlock.ServerBlock.RemoteDebuggingBlock,
     private val env: ServerEnvironment,
-    private val siteLayout: SiteLayout,
+    private val siteLayout: Provider<SiteLayout>,
     private val reuseServer: Boolean,
 ) : KobwebTask("Start a Kobweb server") {
 
@@ -77,7 +78,7 @@ abstract class KobwebStartTask @Inject constructor(
         val processParams = buildList<String> {
             add("${javaHome.invariantSeparatorsPath}/bin/java")
             add(env.toSystemPropertyParam())
-            add(siteLayout.toSystemPropertyParam())
+            add(siteLayout.get().toSystemPropertyParam())
             // See: https://ktor.io/docs/development-mode.html#system-property)
             add("-Dio.ktor.development=${env == ServerEnvironment.DEV}")
             if (env == ServerEnvironment.DEV && remoteDebuggingEnabled) {


### PR DESCRIPTION
Gradle 9.1 will support more fine-grained tracking of property use, so this change will allow reusing configuration cache even when changing site layouts.