### PR TITLE
Add built-in sitemap generation support for SEO (#701)

### DIFF
--- a/playground/site/build.gradle.kts
+++ b/playground/site/build.gradle.kts
@@ -20,9 +20,18 @@ kobweb {
             }
         }
         //testing new feature
-        sitemap {
-            baseUrl.set("http://localhost:8080")
-            excludeRoutes.addAll("/admin", "/api","/example/")
+        generateSitemap("http://localhost:8080") {
+            // Define routes to exclude from sitemap
+            val excludedPrefixes = listOf("/fruits", "/markdown", "/api")
+            filter.set {
+                // Exclude dynamic routes (default behavior)
+//                val hasDynamicRoute = route.contains('{') && route.contains('}')
+                // Exclude routes with specified prefixes
+                val hasExcludedPrefix = excludedPrefixes.any { prefix -> route.startsWith(prefix) }
+                // Include only if both conditions are false
+               hasExcludedPrefix
+               !hasExcludedPrefix
+            }
         }
     }
     markdown {

--- a/playground/site/build.gradle.kts
+++ b/playground/site/build.gradle.kts
@@ -19,6 +19,11 @@ kobweb {
                 enableSelfHosting()
             }
         }
+        //testing new feature
+        sitemap {
+            baseUrl.set("http://localhost:8080")
+            excludeRoutes.addAll("/admin", "/api","/example")
+        }
     }
     markdown {
         defaultLayout.set(".components.layouts.MarkdownLayout")

--- a/playground/site/build.gradle.kts
+++ b/playground/site/build.gradle.kts
@@ -22,7 +22,7 @@ kobweb {
         //testing new feature
         sitemap {
             baseUrl.set("http://localhost:8080")
-            excludeRoutes.addAll("/admin", "/api","/example")
+            excludeRoutes.addAll("/admin", "/api","/example/")
         }
     }
     markdown {

--- a/playground/site/build.gradle.kts
+++ b/playground/site/build.gradle.kts
@@ -22,14 +22,10 @@ kobweb {
         //testing new feature
         generateSitemap("http://localhost:8080") {
             // Define routes to exclude from sitemap
-            val excludedPrefixes = listOf("/fruits", "/markdown", "/api")
+            val excludedPrefixes = listOf("/fruits", "/markdown")
             filter.set {
-                // Exclude dynamic routes (default behavior)
-//                val hasDynamicRoute = route.contains('{') && route.contains('}')
-                // Exclude routes with specified prefixes
+             // Exclude routes with specified prefixes
                 val hasExcludedPrefix = excludedPrefixes.any { prefix -> route.startsWith(prefix) }
-                // Include only if both conditions are false
-               hasExcludedPrefix
                !hasExcludedPrefix
             }
         }

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/extensions/AppBlock.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/extensions/AppBlock.kt
@@ -333,7 +333,7 @@ abstract class AppBlock @Inject constructor(
     /**
      * A sub-block for defining properties related to sitemap generation for SEO.
      */
-    abstract class SitemapBlock @Inject constructor() : ExtensionAware {
+    abstract class SitemapBlock : ExtensionAware {
 
 
         /**
@@ -373,7 +373,7 @@ abstract class AppBlock @Inject constructor(
          * 
          * @see [SitemapFilterContext]
          */
-        @get:Internal // Avoid serialization issues with lambdas
+        @get:Nested // Avoid serialization issues with lambdas
         abstract val filter: Property<SitemapFilterContext.() -> Boolean>
 
         /**

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/extensions/AppBlock.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/extensions/AppBlock.kt
@@ -346,7 +346,9 @@ abstract class AppBlock @Inject constructor(
          * This will be prepended to all routes in the sitemap.
          *
          * IMPORTANT: If your site is deployed under a base path (e.g., GitHub Pages project site),
-         * include it in the baseUrl: "https://username.github.io/project-name"
+         * include it in the baseUrl: "https://username.github.io/project-name".
+         * If the base path is configured and not included in the baseUrl, a warning will be printed and the
+         * generated links may be incorrect.
          */
         @get:Input
         abstract val baseUrl: Property<String>

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/extensions/AppBlock.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/extensions/AppBlock.kt
@@ -376,6 +376,22 @@ abstract class AppBlock @Inject constructor(
         @get:Internal // Avoid serialization issues with lambdas
         abstract val filter: Property<SitemapFilterContext.() -> Boolean>
 
+        /**
+         * Internal flag to track whether sitemap generation has been enabled.
+         * This is used to conditionally register the sitemap generation task.
+         */
+        @get:Internal
+        internal var isEnabled: Boolean = false
+            private set
+
+        /**
+         * Internal method to mark sitemap generation as enabled.
+         * Called by the generateSitemap function.
+         */
+        internal fun markAsEnabled() {
+            isEnabled = true
+        }
+
         init {
             extraRoutes.set(emptyList())
             // Default filter accepts all routes (dynamic route exclusion is handled in the task)
@@ -638,6 +654,7 @@ abstract class AppBlock @Inject constructor(
     fun generateSitemap(baseUrl: String, config: SitemapBlock.() -> Unit = {}) {
         sitemap.baseUrl.set(baseUrl)
         config(sitemap)
+        sitemap.markAsEnabled()
     }
 
     init {

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebGenerateSitemapTask.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebGenerateSitemapTask.kt
@@ -1,13 +1,11 @@
 package com.varabyte.kobweb.gradle.application.tasks
 
 import com.varabyte.kobweb.gradle.application.extensions.AppBlock
-import com.varabyte.kobweb.gradle.application.extensions.sitemap
 import org.gradle.api.GradleException
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
@@ -81,7 +79,9 @@ abstract class KobwebGenerateSitemapTask : KobwebGenerateTask("Generate an XML s
             logger.warn("Generated sitemap is ${sitemapXml.length / (1024 * 1024)}MB, exceeding the 50MB limit.")
         }
 
-        sitemapFile.get().asFile.writeText(sitemapXml)
+        val outputFile = sitemapFile.get().asFile
+        outputFile.parentFile.mkdirs()
+        outputFile.writeText(sitemapXml)
 
         logger.info("Generated sitemap with ${filteredRoutes.size} routes.")
     }

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebGenerateSitemapTask.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebGenerateSitemapTask.kt
@@ -1,0 +1,170 @@
+package com.varabyte.kobweb.gradle.application.tasks
+
+import com.varabyte.kobweb.gradle.application.extensions.AppBlock
+import com.varabyte.kobweb.gradle.application.extensions.sitemap
+import org.gradle.api.GradleException
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import javax.inject.Inject
+
+abstract class KobwebGenerateSitemapTask @Inject constructor(
+) : KobwebGenerateTask("Generate an XML sitemap for the site") {
+
+    @get:Input
+    abstract val baseUrl: Property<String>
+
+    @get:Input
+    abstract val includeDynamicRoutes: Property<Boolean>
+
+    @get:Input
+    abstract val extraRoutes: ListProperty<String>
+
+    @get:Input
+    abstract val excludeRoutes: SetProperty<String>
+
+    @get:Input
+    abstract val routes: ListProperty<String>
+
+    /**
+     * A filter to determine which routes should be included in the sitemap.
+     * Return true to include the route, false to exclude it.
+     *
+     * Note: This is marked @Internal to avoid configuration cache issues with lambda serialization.
+     */
+    @get:Internal
+    abstract val routeFilter: Property<(String) -> Boolean>
+
+    @get:OutputFile
+    abstract val sitemapFile: RegularFileProperty
+
+    @TaskAction
+    fun execute() {
+        // Skip execution if baseUrl is not configured
+        if (!baseUrl.isPresent) {
+            logger.info("Skipping sitemap generation as baseUrl is not configured")
+            return
+        }
+
+        val baseUrlValue = baseUrl.get()
+        val includeDynamic = includeDynamicRoutes.get()
+        val extraRoutesValue = extraRoutes.get()
+        val excludeRoutesValue = excludeRoutes.get()
+        val routeFilterValue = routeFilter.orNull
+
+        // Validate baseUrl
+        validateBaseUrl(baseUrlValue)
+
+        // Start with discovered routes
+        val allRoutes = routes.get().toMutableSet()
+
+        // Add extra routes
+        allRoutes.addAll(extraRoutesValue)
+
+        // Apply filters
+        val filteredRoutes = allRoutes
+            .filter { route ->
+                // Exclude routes that match any exclude pattern (prefix or exact match)
+                if (isRouteExcluded(route, excludeRoutesValue)) return@filter false
+
+                // Exclude dynamic routes if configured (stricter check)
+                if (!includeDynamic && isDynamicRoute(route)) return@filter false
+
+                // Apply custom filter if provided
+                routeFilterValue?.invoke(route) ?: true
+            }
+            .sorted()
+
+        // Check size limits and warn
+        if (filteredRoutes.size > 50000) {
+            logger.warn("Sitemap contains ${filteredRoutes.size} URLs, exceeding the 50,000 URL limit. Consider using excludeRoutes to reduce size.")
+        }
+
+        // Generate XML sitemap
+        val sitemapXml = generateSitemapXml(baseUrlValue, filteredRoutes)
+
+        // Check size limit
+        if (sitemapXml.length > 50 * 1024 * 1024) { // 50MB
+            logger.warn("Generated sitemap is ${sitemapXml.length / (1024 * 1024)}MB, exceeding the 50MB limit.")
+        }
+
+        sitemapFile.get().asFile.writeText(sitemapXml)
+
+        logger.lifecycle("Generated sitemap with ${filteredRoutes.size} routes")
+        if (filteredRoutes.size <= 20) {
+            // Only log individual routes for small sitemaps to avoid noise
+            filteredRoutes.forEach { route ->
+                logger.lifecycle("  ${createAbsoluteUrl(baseUrlValue, route)}")
+            }
+        }
+    }
+
+    private fun validateBaseUrl(baseUrl: String) {
+        when {
+            baseUrl.isBlank() -> throw GradleException("sitemap.baseUrl cannot be empty")
+            !baseUrl.startsWith("http://") && !baseUrl.startsWith("https://") -> {
+                throw GradleException(
+                    "sitemap.baseUrl must be absolute (start with http:// or https://), got: $baseUrl\n" +
+                        "Examples:\n" +
+                        "  Production: \"https://mysite.com\"\n" +
+                        "  Testing: \"http://localhost:8080\""
+                )
+            }
+
+            baseUrl.endsWith("/") ->
+                throw GradleException("sitemap.baseUrl should not end with a trailing slash, got: $baseUrl")
+        }
+    }
+
+    private fun isDynamicRoute(route: String): Boolean {
+        // More precise check than just contains('{')
+        return route.contains('{') && route.contains('}')
+    }
+
+    private fun isRouteExcluded(route: String, excludeRoutes: Set<String>): Boolean {
+        return excludeRoutes.any { excludeRoute ->
+            route.startsWith(excludeRoute) || route == excludeRoute
+        }
+    }
+
+    private fun createAbsoluteUrl(baseUrl: String, route: String): String {
+        val cleanBaseUrl = baseUrl.trimEnd('/')
+        val cleanRoute = if (route.startsWith("/")) route else "/$route"
+        return cleanBaseUrl + cleanRoute
+    }
+
+    private fun generateSitemapXml(baseUrl: String, routes: List<String>): String {
+        return buildString {
+            appendLine("""<?xml version="1.0" encoding="UTF-8"?>""")
+            appendLine("""<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">""")
+
+            routes.forEach { route ->
+                val absoluteUrl = createAbsoluteUrl(baseUrl, route)
+                val escapedUrl = escapeXml(absoluteUrl)
+
+                appendLine("  <url>")
+                appendLine("    <loc>$escapedUrl</loc>")
+                // Note: We don't include <lastmod> as we don't have reliable modification dates
+                // Future enhancement could track file modification times or add annotation support
+                appendLine("  </url>")
+            }
+
+            appendLine("</urlset>")
+        }
+    }
+
+    private fun escapeXml(text: String): String {
+        return text
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace("\"", "&quot;")
+            .replace("'", "&apos;")
+    }
+}

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebGenerateSitemapTask.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebGenerateSitemapTask.kt
@@ -105,10 +105,10 @@ abstract class KobwebGenerateSitemapTask : KobwebGenerateTask("Generate an XML s
             try {
                 val baseUrlPath = java.net.URI(baseUrl).path
                 if (baseUrlPath.isNotEmpty() && !baseUrlPath.endsWith("/$basePathValue")) {
-                    throw GradleException(
+                    logger.warn(
                         "sitemap.baseUrl path ('$baseUrlPath') does not end with the project's configured " +
-                            "base path ('/$basePathValue'). This will result in incorrect sitemap links. " +
-                            "Please set baseUrl to include the base path, e.g., \"https://example.com/$basePathValue\"."
+                            "base path ('/$basePathValue'). Sitemap URLs may be incorrect. " +
+                            "Consider setting baseUrl to include the base path, e.g., \"https://example.com/$basePathValue\"."
                     )
                 }
             } catch (e: java.net.URISyntaxException) {

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/util/site/ProjectExtensions.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/util/site/ProjectExtensions.kt
@@ -38,12 +38,14 @@ import org.jetbrains.kotlin.gradle.utils.named
  * ```
  */
 val Project.kobwebSiteRoutes: Provider<List<String>>
-    get() = tasks.named<KobwebCacheAppFrontendDataTask>("kobwebCacheAppFrontendData").map { task ->
-        val pageEntries =
-            Json.decodeFromString<AppFrontendData>(task.appDataFile.get().asFile.readText()).frontendData.pages
-        pageEntries
-            .asSequence()
-            .map { it.route }
-            .sorted()
-            .toList()
+    get() = tasks.named<KobwebCacheAppFrontendDataTask>("kobwebCacheAppFrontendData").flatMap { task ->
+        task.appDataFile.map { file ->
+            val pageEntries =
+                Json.decodeFromString<AppFrontendData>(file.asFile.readText()).frontendData.pages
+            pageEntries
+                .asSequence()
+                .map { it.route }
+                .sorted()
+                .toList()
+        }
     }


### PR DESCRIPTION
## Overview

Implements automatic XML sitemap generation for Kobweb applications to improve SEO and search engine discoverability.

Closes #701

## Implementation Details

### New Features
- **Automatic sitemap generation**: Creates `sitemap.xml` at site root (`/sitemap.xml`)
- **Smart route discovery**: Uses existing `@Page` annotation detection (includes markdown-generated pages)
- **Flexible configuration**: DSL block under `kobweb.app.sitemap { ... }`
- **Dynamic route filtering**: Excludes parameterized routes like `/users/{id}` by default
- **Custom filtering**: Support for `excludeRoutes`, `extraRoutes`, and custom `routeFilter` lambdas
- **Localhost testing**: Supports `http://localhost:8080` for development testing
- **Standards compliant**: Generates proper XML sitemaps following sitemaps.org specification

### Task Dependencies
- Runs after markdown processing (`kobwebxMarkdownProcess`) when present
- Integrated into resource processing pipeline
- Outputs directly to `src/jsMain/resources/public/sitemap.xml`

### Configuration Examples

**Basic usage:**
```kotlin
kobweb {
    app {
        sitemap {
            baseUrl.set("https://mysite.com")
        }
    }
}
```

**Advanced configuration:**
```kotlin
kobweb {
    app {
        sitemap {
            baseUrl.set("https://mysite.com")
            extraRoutes.addAll("/blog/post-1", "/products/special")
            excludeRoutes.addAll("/admin", "/internal")
            routeFilter.set { !it.contains("/temp/") }
        }
    }
}
```

**Localhost testing:**
```kotlin
kobweb {
    app {
        sitemap {
            baseUrl.set("http://localhost:8080")
        }
    }
}
```

### Key Benefits
- **Zero configuration**: Works out-of-the-box for most sites with just `baseUrl`
- **Markdown integration**: Automatically includes markdown-generated pages
- **Development friendly**: Easy to test locally with localhost URLs
- **Production ready**: Handles large sites with size limit warnings
- **SEO optimized**: Places sitemap at standard `/sitemap.xml` location

### Files Added/Modified
- **New**: `KobwebGenerateSitemapTask.kt` - Main sitemap generation task
- **Modified**: `AppBlock.kt` - Added `SitemapBlock` configuration DSL
- **Modified**: `KobwebApplicationPlugin.kt` - Task registration and dependency wiring

### Testing
- Supports `http://localhost:8080` for local development testing
- Generates sitemap at `src/jsMain/resources/public/sitemap.xml`
- Accessible at `/sitemap.xml` when server is running
- Works with both development (`kobweb start`) and production (`kobweb export`) workflows

## Breaking Changes
None - this is purely additive functionality that only activates when `baseUrl` is configured.
