### PR TITLE
Allow adding body scripts in a kobweb block (#299)

### DIFF
--- a/playground/site/build.gradle.kts
+++ b/playground/site/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.varabyte.kobweb.gradle.application.extensions.body
 import com.varabyte.kobweb.gradle.application.util.configAsKobwebApplication
 import com.varabyte.kobwebx.gradle.markdown.handlers.SilkCalloutBlockquoteHandler
 import kotlinx.html.script
@@ -21,14 +22,14 @@ kobweb {
                 enableSelfHosting()
             }
             // Test the new body block functionality
-            body.add {
+            body {
                 script {
                     src = "https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
                     attributes["integrity"] = "sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz"
                     attributes["crossorigin"] = "anonymous"
                 }
             }
-            body.add {
+            body {
                 script {
                     unsafe {
                         raw(

--- a/playground/site/build.gradle.kts
+++ b/playground/site/build.gradle.kts
@@ -1,5 +1,7 @@
 import com.varabyte.kobweb.gradle.application.util.configAsKobwebApplication
 import com.varabyte.kobwebx.gradle.markdown.handlers.SilkCalloutBlockquoteHandler
+import kotlinx.html.script
+import kotlinx.html.unsafe
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
@@ -17,6 +19,26 @@ kobweb {
         index {
             interceptUrls {
                 enableSelfHosting()
+            }
+            // Test the new body block functionality
+            body.add {
+                script {
+                    src = "https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
+                    attributes["integrity"] = "sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz"
+                    attributes["crossorigin"] = "anonymous"
+                }
+            }
+            body.add {
+                script {
+                    unsafe {
+                        raw(
+                            """
+                            // Test analytics script
+                            console.log('Body block test: Analytics script loaded');
+                        """.trimIndent()
+                        )
+                    }
+                }
             }
         }
     }

--- a/playground/site/build.gradle.kts
+++ b/playground/site/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.varabyte.kobweb.gradle.application.extensions.BodyTarget
+import com.varabyte.kobweb.gradle.application.extensions.body
 import com.varabyte.kobweb.gradle.application.util.configAsKobwebApplication
 import com.varabyte.kobwebx.gradle.markdown.handlers.SilkCalloutBlockquoteHandler
 import kotlinx.html.script
@@ -20,23 +22,44 @@ kobweb {
             interceptUrls {
                 enableSelfHosting()
             }
-            // Test the new body block functionality
-            body.add {
+
+
+            // Test the basic body block functionality (AFTER_SCRIPT position - default)
+            body {
                 script {
                     src = "https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
                     attributes["integrity"] = "sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz"
                     attributes["crossorigin"] = "anonymous"
                 }
             }
-            body.add {
+            body {
                 script {
                     unsafe {
                         raw(
                             """
-                            // Test analytics script
-                            console.log('Body block test: Analytics script loaded');
+                            console.log('AFTER_SCRIPT position: Analytics script loaded');
+                            console.log('This script runs after the main Kobweb app script');
+                            console.log('Page title:', document.title);
                         """.trimIndent()
                         )
+                    }
+                }
+            }
+
+            // Test START position - elements before root div and main script
+            body(target = BodyTarget.START) {
+                script {
+                    unsafe {
+                        raw("console.log('START position: Early script loaded before main app');")
+                    }
+                }
+            }
+
+            // Test END position - elements at the very end of body
+            body(target = BodyTarget.END) {
+                script {
+                    unsafe {
+                        raw("console.log('END position: Final script loaded at end of body');")
                     }
                 }
             }

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/extensions/AppBlock.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/extensions/AppBlock.kt
@@ -640,3 +640,11 @@ fun AppBlock.IndexBlock.excludeAllHtmlFromDependencies() {
     excludeHtmlForDependencies.set(listOf(""))
     excludeHtmlForDependencies.disallowChanges()
 }
+
+
+/**
+ * Add elements to the body at the default position (after main script).
+ */
+fun AppBlock.IndexBlock.body(block: BODY.() -> Unit) {
+    body.add(block)
+}

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebGenerateSiteIndexTask.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/tasks/KobwebGenerateSiteIndexTask.kt
@@ -335,8 +335,18 @@ abstract class KobwebGenerateSiteIndexTask @Inject constructor(
             }
         }
 
-        // Collect body elements (simpler than head - no library support initially)
-        val bodyElements: List<String> = indexBlock.body.get().map { HtmlUtil.serializeBodyContents(it) }
+        // Collect body elements
+        // AFTER_SCRIPT (default): reuse existing `body` property for backward compatibility
+        val bodyAfterScriptElements: List<String> = indexBlock.serializedBody.get().let {
+            if (it.isBlank()) emptyList() else listOf(it)
+        }
+        // START and END positions are new
+        val bodyStartElements: List<String> = indexBlock.serializedBodyStart.get().let {
+            if (it.isBlank()) emptyList() else listOf(it)
+        }
+        val bodyEndElements: List<String> = indexBlock.serializedBodyEnd.get().let {
+            if (it.isBlank()) emptyList() else listOf(it)
+        }
 
         val basePath = BasePath(confInputs.basePath)
         getGenIndexFile().get().asFile.writeText(
@@ -368,17 +378,28 @@ abstract class KobwebGenerateSiteIndexTask @Inject constructor(
                 // a subdirectory.
                 src = basePath.prependTo(confInputs.script.substringAfterLast("/").prefixIfNot("/")),
                 scriptAttributes = indexBlock.scriptAttributes.get(),
-                bodyElements = bodyElements,
+                bodyStartElements = bodyStartElements,
+                bodyAfterScriptElements = bodyAfterScriptElements,
+                bodyEndElements = bodyEndElements,
                 buildTarget = buildTarget
             )
         )
 
-        // Optional: Log body elements like we do for head ~ feel free to remove this if not needed
-        if (bodyElements.isNotEmpty()) {
+        // Log final body elements grouped by position
+        if (bodyStartElements.isNotEmpty() || bodyAfterScriptElements.isNotEmpty() || bodyEndElements.isNotEmpty()) {
             logger.lifecycle("Final <body> elements:")
-            logger.lifecycle("```")
-            bodyElements.forEach { logger.lifecycle("  ${it.replace("\n", "")}") }
-            logger.lifecycle("```")
+            if (bodyStartElements.isNotEmpty()) {
+                logger.lifecycle("  START position:")
+                bodyStartElements.forEach { logger.lifecycle("    ${it.replace("\n", "")}") }
+            }
+            if (bodyAfterScriptElements.isNotEmpty()) {
+                logger.lifecycle("  AFTER_SCRIPT position (default):")
+                bodyAfterScriptElements.forEach { logger.lifecycle("    ${it.replace("\n", "")}") }
+            }
+            if (bodyEndElements.isNotEmpty()) {
+                logger.lifecycle("  END position:")
+                bodyEndElements.forEach { logger.lifecycle("    ${it.replace("\n", "")}") }
+            }
         }
     }
 }

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/templates/IndexTemplate.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/templates/IndexTemplate.kt
@@ -74,6 +74,7 @@ fun createIndexFile(
     title: String,
     lang: String,
     headElements: Iterable<String>,
+    bodyElements: Iterable<String>,
     src: String,
     scriptAttributes: Map<String, String>,
     buildTarget: BuildTarget
@@ -106,6 +107,11 @@ fun createIndexFile(
                     script {
                         this.src = src
                         attributes.putAll(scriptAttributes)
+                    }
+
+                    // Add user body elements
+                    bodyElements.forEach { elements ->
+                        unsafe { raw(elements) }
                     }
                 }
             }

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/templates/IndexTemplate.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/templates/IndexTemplate.kt
@@ -74,9 +74,7 @@ fun createIndexFile(
     title: String,
     lang: String,
     headElements: Iterable<String>,
-    bodyStartElements: Iterable<String>,
-    bodyAfterScriptElements: Iterable<String>,
-    bodyEndElements: Iterable<String>,
+    bodyElements: Iterable<String>,
     src: String,
     scriptAttributes: Map<String, String>,
     buildTarget: BuildTarget
@@ -96,11 +94,6 @@ fun createIndexFile(
                 }
 
                 body {
-                    // BodyTarget.START elements
-                    bodyStartElements.forEach { elements ->
-                        unsafe { raw(elements) }
-                    }
-
                     div {
                         id = "_kobweb-root"
                         // Fill max size just in case user sets html / body size
@@ -116,13 +109,8 @@ fun createIndexFile(
                         attributes.putAll(scriptAttributes)
                     }
 
-                    // BodyTarget.AFTER_SCRIPT elements (default)
-                    bodyAfterScriptElements.forEach { elements ->
-                        unsafe { raw(elements) }
-                    }
-
-                    // BodyTarget.END elements
-                    bodyEndElements.forEach { elements ->
+                    // Add user body elements
+                    bodyElements.forEach { elements ->
                         unsafe { raw(elements) }
                     }
                 }

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/templates/IndexTemplate.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/templates/IndexTemplate.kt
@@ -74,7 +74,9 @@ fun createIndexFile(
     title: String,
     lang: String,
     headElements: Iterable<String>,
-    bodyElements: Iterable<String>,
+    bodyStartElements: Iterable<String>,
+    bodyAfterScriptElements: Iterable<String>,
+    bodyEndElements: Iterable<String>,
     src: String,
     scriptAttributes: Map<String, String>,
     buildTarget: BuildTarget
@@ -94,6 +96,11 @@ fun createIndexFile(
                 }
 
                 body {
+                    // BodyTarget.START elements
+                    bodyStartElements.forEach { elements ->
+                        unsafe { raw(elements) }
+                    }
+
                     div {
                         id = "_kobweb-root"
                         // Fill max size just in case user sets html / body size
@@ -109,8 +116,13 @@ fun createIndexFile(
                         attributes.putAll(scriptAttributes)
                     }
 
-                    // Add user body elements
-                    bodyElements.forEach { elements ->
+                    // BodyTarget.AFTER_SCRIPT elements (default)
+                    bodyAfterScriptElements.forEach { elements ->
+                        unsafe { raw(elements) }
+                    }
+
+                    // BodyTarget.END elements
+                    bodyEndElements.forEach { elements ->
                         unsafe { raw(elements) }
                     }
                 }


### PR DESCRIPTION
## Overview
This PR adds support for injecting custom `<body>` elements (such as scripts, meta tags, and other HTML content) directly through the Kobweb application block configuration, enabling developers to add analytics, Bootstrap, and other scripts without modifying HTML templates. 
Closes #299 


## What's Changed
- **Added `AppBlock.body` configuration block** for defining custom `<body>` content in `build.gradle.kts`
- **Enhanced `KobwebGenerateSiteIndexTask`** to process and inject custom body elements during site generation
- **Added `serializeBodyContents` utility** for creating and serializing custom `<body>` content blocks
- **Updated `IndexTemplate`** to support custom `<body>` element injection
- **Added comprehensive logging** during index generation for better visibility of injected elements
- **Extended `HtmlUtil`** with body content serialization capabilities

## API Usage
Developers can now add custom body content in their `build.gradle.kts`:

```kotlin
kobweb {
    app {
        index {
            description.set("My awesome Kobweb app")
            
            // Add custom body elements using body.add {}
            body.add {
                script {
                    src = "https://www.googletagmanager.com/gtag/js?id=GA_MEASUREMENT_ID"
                    async = true
                }
            }
            
            body.add {
                script {
                    src = "https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
                    attributes["integrity"] = "sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz"
                    attributes["crossorigin"] = "anonymous"
                }
            }
            
            body.add {
                script {
                    unsafe {
                        raw("""
                            // Custom analytics or other JavaScript
                            console.log('Custom body script loaded');
                        """.trimIndent())
                    }
                }
            }
        }
    }
}
```

## Use Cases
- Adding analytics scripts (Google Analytics, Meta Pixel, etc.)
- Including Bootstrap or other CSS/JS frameworks that need body injection
- Injecting custom scripts that need to be placed in the `<body>` tag
- Adding meta tags or other HTML content that belongs in the document body
- Supporting third-party integrations that require specific script placement

## Implementation Details
- **File Changes**: 5 files modified across the application plugin
- **Backward Compatibility**: Fully backward compatible - no breaking changes
- **Build Integration**: Seamlessly integrates with existing Kobweb build process
- **Template System**: Leverages existing index template generation infrastructure
- **API Design**: Uses `body.add {}` blocks for adding multiple body elements

## Testing
- ✅ Tested with Bootstrap integration
- ✅ Tested with analytics script injection  
- ✅ Verified proper HTML serialization and template integration
- ✅ Confirmed logging output during site generation
- ✅ Validated backward compatibility with existing projects

## Breaking Changes
None - this is a purely additive feature that maintains full backward compatibility.
