### PR TITLE
Add new SVG icons to the current list

### DIFF
--- a/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/icons/CalendarIcon.kt
+++ b/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/icons/CalendarIcon.kt
@@ -1,0 +1,16 @@
+package com.varabyte.kobweb.silk.components.icons
+
+import androidx.compose.runtime.Composable
+import com.varabyte.kobweb.compose.dom.svg.Path
+import com.varabyte.kobweb.compose.dom.svg.ViewBox
+import com.varabyte.kobweb.compose.ui.Modifier
+import com.varabyte.kobweb.compose.ui.toAttrs
+
+@Composable
+fun CalendarIcon(modifier: Modifier = Modifier) {
+    createIcon(viewBox = ViewBox(0, 0, 24, 24), renderStyle = IconRenderStyle.Fill(), attrs = modifier.toAttrs()) {
+        Path {
+            d("M19 4h-2V2h-2v2H9V2H7v2H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2m0 16H5V9h14v11m0-13H5V6h14v1z")
+        }
+    }
+}

--- a/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/icons/CheckCircleIcon.kt
+++ b/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/icons/CheckCircleIcon.kt
@@ -1,0 +1,23 @@
+package com.varabyte.kobweb.silk.components.icons
+
+import androidx.compose.runtime.Composable
+import com.varabyte.kobweb.compose.dom.svg.Path
+import com.varabyte.kobweb.compose.dom.svg.ViewBox
+import com.varabyte.kobweb.compose.ui.Modifier
+import com.varabyte.kobweb.compose.ui.toAttrs
+
+@Composable
+fun CheckCircleIcon(modifier: Modifier = Modifier) {
+    // We use a viewBox of 24x24, a common standard for icons.
+    // IconRenderStyle.Stroke() ensures the icon is an outline.
+    createIcon(viewBox = ViewBox(0, 0, 24, 24), renderStyle = IconRenderStyle.Stroke(2), attrs = modifier.toAttrs()) {
+        // This path draws the circle part of the icon.
+        Path {
+            d("M12 2a10 10 0 100 20 10 10 0 000-20z")
+        }
+        // This path draws the checkmark part of the icon.
+        Path {
+            d("M9 12l2 2 4-4")
+        }
+    }
+}

--- a/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/icons/ClipboardIcon.kt
+++ b/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/icons/ClipboardIcon.kt
@@ -1,0 +1,16 @@
+package com.varabyte.kobweb.silk.components.icons
+
+import androidx.compose.runtime.Composable
+import com.varabyte.kobweb.compose.dom.svg.Path
+import com.varabyte.kobweb.compose.dom.svg.ViewBox
+import com.varabyte.kobweb.compose.ui.Modifier
+import com.varabyte.kobweb.compose.ui.toAttrs
+
+@Composable
+fun ClipboardIcon(modifier: Modifier = Modifier) {
+    createIcon(viewBox = ViewBox(0, 0, 24, 24), renderStyle = IconRenderStyle.Stroke(2), attrs = modifier.toAttrs()) {
+        Path {
+            d("M8 5.00005C7.01165 5.00082 6.49359 5.01338 6.09202 5.21799C5.71569 5.40973 5.40973 5.71569 5.21799 6.09202C5 6.51984 5 7.07989 5 8.2V17.8C5 18.9201 5 19.4802 5.21799 19.908C5.40973 20.2843 5.71569 20.5903 6.09202 20.782C6.51984 21 7.07989 21 8.2 21H15.8C16.9201 21 17.4802 21 17.908 20.782C18.2843 20.5903 18.5903 20.2843 18.782 19.908C19 19.4802 19 18.9201 19 17.8V8.2C19 7.07989 19 6.51984 18.782 6.09202C18.5903 5.71569 18.2843 5.40973 17.908 5.21799C17.5064 5.01338 16.9884 5.00082 16 5.00005M8 5.00005V7H16V5.00005M8 5.00005V4.70711C8 4.25435 8.17986 3.82014 8.5 3.5C8.82014 3.17986 9.25435 3 9.70711 3H14.2929C14.7456 3 15.1799 3.17986 15.5 3.5C15.8201 3.82014 16 4.25435 16 4.70711V5.00005M15 12H12M15 16H12M9 12H9.01M9 16H9.01")
+        }
+    }
+}

--- a/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/icons/CodeIcon.kt
+++ b/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/icons/CodeIcon.kt
@@ -1,0 +1,29 @@
+package com.varabyte.kobweb.silk.components.icons
+
+import androidx.compose.runtime.Composable
+import com.varabyte.kobweb.compose.dom.svg.Path
+import com.varabyte.kobweb.compose.dom.svg.ViewBox
+import com.varabyte.kobweb.compose.ui.Modifier
+import com.varabyte.kobweb.compose.ui.toAttrs
+
+@Composable
+fun CodeIcon(modifier: Modifier = Modifier) {
+    createIcon(
+        viewBox = ViewBox(0, 0, 24, 24),
+        renderStyle = IconRenderStyle.Stroke(2),
+        attrs = modifier.toAttrs()
+    ) {
+        // Left angle bracket <
+        Path {
+            d("M8 8l-4 4 4 4")
+        }
+        // Forward slash /
+        Path {
+            d("M12 16l4-8")
+        }
+        // Right angle bracket >
+        Path {
+            d("M16 8l4 4-4 4")
+        }
+    }
+}

--- a/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/icons/EditIcon.kt
+++ b/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/icons/EditIcon.kt
@@ -1,0 +1,18 @@
+package com.varabyte.kobweb.silk.components.icons
+
+import androidx.compose.runtime.Composable
+import com.varabyte.kobweb.compose.dom.svg.Path
+import com.varabyte.kobweb.compose.dom.svg.ViewBox
+import com.varabyte.kobweb.compose.ui.Modifier
+import com.varabyte.kobweb.compose.ui.toAttrs
+
+@Composable
+fun EditIcon(modifier: Modifier = Modifier) {
+    // We use a standard 24x24 viewBox and set the render style to stroke for an outlined icon.
+    createIcon(viewBox = ViewBox(0, 0, 24, 24), renderStyle = IconRenderStyle.Stroke(2), attrs = modifier.toAttrs()) {
+        // This path data draws a classic pen/pencil icon.
+        Path {
+            d("M17 3a2.828 2.828 0 114 4L7.5 20.5 2 22l1.5-5.5L17 3z")
+        }
+    }
+}

--- a/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/icons/EyeIcon.kt
+++ b/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/icons/EyeIcon.kt
@@ -1,0 +1,25 @@
+package com.varabyte.kobweb.silk.components.icons
+
+import androidx.compose.runtime.Composable
+import com.varabyte.kobweb.compose.dom.svg.Path
+import com.varabyte.kobweb.compose.dom.svg.ViewBox
+import com.varabyte.kobweb.compose.ui.Modifier
+import com.varabyte.kobweb.compose.ui.toAttrs
+
+@Composable
+fun EyeIcon(modifier: Modifier = Modifier) {
+    createIcon(
+        viewBox = ViewBox(0, 0, 24, 24),
+        renderStyle = IconRenderStyle.Stroke(2),
+        attrs = modifier.toAttrs()
+    ) {
+        // Outer eye shape
+        Path {
+            d("M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z")
+        }
+        // Pupil
+        Path {
+            d("M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6z")
+        }
+    }
+}

--- a/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/icons/EyeOffIcon.kt
+++ b/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/icons/EyeOffIcon.kt
@@ -1,0 +1,33 @@
+package com.varabyte.kobweb.silk.components.icons
+
+import androidx.compose.runtime.Composable
+import com.varabyte.kobweb.compose.dom.svg.Path
+import com.varabyte.kobweb.compose.dom.svg.ViewBox
+import com.varabyte.kobweb.compose.ui.Modifier
+import com.varabyte.kobweb.compose.ui.toAttrs
+
+@Composable
+fun EyeOffIcon(modifier: Modifier = Modifier) {
+    createIcon(
+        viewBox = ViewBox(0, 0, 24, 24),
+        renderStyle = IconRenderStyle.Stroke(2),
+        attrs = modifier.toAttrs()
+    ) {
+        // Outer eye shape
+        Path {
+            d("M17.94 17.94A10.94 10.94 0 0 1 12 19c-7 0-11-7-11-7a20.87 20.87 0 0 1 5.06-5.94")
+        }
+        // Inner eye shape (hidden state)
+        Path {
+            d("M9.88 9.88a3 3 0 0 0 4.24 4.24")
+        }
+        // Slash across the eye
+        Path {
+            d("M1 1l22 22")
+        }
+        // Remaining outer eye arc
+        Path {
+            d("M6.1 6.1A10.94 10.94 0 0 1 12 5c7 0 11 7 11 7a20.87 20.87 0 0 1-4.06 4.94")
+        }
+    }
+}

--- a/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/icons/LockIcon.kt
+++ b/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/icons/LockIcon.kt
@@ -1,0 +1,25 @@
+package com.varabyte.kobweb.silk.components.icons
+
+import androidx.compose.runtime.Composable
+import com.varabyte.kobweb.compose.dom.svg.Path
+import com.varabyte.kobweb.compose.dom.svg.ViewBox
+import com.varabyte.kobweb.compose.ui.Modifier
+import com.varabyte.kobweb.compose.ui.toAttrs
+
+@Composable
+fun LockIcon(modifier: Modifier = Modifier) {
+    createIcon(
+        viewBox = ViewBox(0, 0, 24, 24),
+        renderStyle = IconRenderStyle.Stroke(2),
+        attrs = modifier.toAttrs()
+    ) {
+        // Lock body
+        Path {
+            d("M5 11h14v10H5z")
+        }
+        // Lock shackle
+        Path {
+            d("M7 11V7a5 5 0 0 1 10 0v4")
+        }
+    }
+}

--- a/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/icons/SearchIcon.kt
+++ b/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/icons/SearchIcon.kt
@@ -1,0 +1,16 @@
+package com.varabyte.kobweb.silk.components.icons
+
+import androidx.compose.runtime.Composable
+import com.varabyte.kobweb.compose.dom.svg.Path
+import com.varabyte.kobweb.compose.dom.svg.ViewBox
+import com.varabyte.kobweb.compose.ui.Modifier
+import com.varabyte.kobweb.compose.ui.toAttrs
+
+@Composable
+fun SearchIcon(modifier: Modifier = Modifier) {
+    createIcon(viewBox = ViewBox(0, 0, 24, 24), renderStyle = IconRenderStyle.Stroke(2), attrs = modifier.toAttrs()) {
+        Path {
+            d("M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z")
+        }
+    }
+}

--- a/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/icons/SettingsIcon.kt
+++ b/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/icons/SettingsIcon.kt
@@ -1,0 +1,36 @@
+package com.varabyte.kobweb.silk.components.icons
+
+import androidx.compose.runtime.Composable
+import com.varabyte.kobweb.compose.dom.svg.Path
+import com.varabyte.kobweb.compose.dom.svg.ViewBox
+import com.varabyte.kobweb.compose.ui.Modifier
+import com.varabyte.kobweb.compose.ui.toAttrs
+
+@Composable
+fun SettingsIcon(modifier: Modifier = Modifier) {
+    createIcon(
+        viewBox = ViewBox(0, 0, 24, 24),
+        renderStyle = IconRenderStyle.Stroke(2),
+        attrs = modifier.toAttrs()
+    ) {
+        Path {
+            d(
+                // Outer gear
+                "M19.14 12.94a7.94 7.94 0 0 0 0-1.88l2.11-1.65" +
+                    "a.5.5 0 0 0 .12-.63l-2-3.46a.5.5 0 0 0-.6-.22" +
+                    "l-2.49 1a7.79 7.79 0 0 0-1.62-.94l-.38-2.65" +
+                    "A.5.5 0 0 0 13 2h-2a.5.5 0 0 0-.5.42l-.38 2.65" +
+                    "a7.79 7.79 0 0 0-1.62.94l-2.49-1a.5.5 0 0 0-.6.22" +
+                    "l-2 3.46a.5.5 0 0 0 .12.63l2.11 1.65a7.94 7.94 0 0 0 0 1.88" +
+                    "l-2.11 1.65a.5.5 0 0 0-.12.63l2 3.46a.5.5 0 0 0 .6.22" +
+                    "l2.49-1a7.79 7.79 0 0 0 1.62.94l.38 2.65A.5.5 0 0 0 11 22h2" +
+                    "a.5.5 0 0 0 .5-.42l.38-2.65a7.79 7.79 0 0 0 1.62-.94" +
+                    "l2.49 1a.5.5 0 0 0 .6-.22l2-3.46a.5.5 0 0 0-.12-.63z"
+            )
+        }
+        Path {
+            // Perfect circle for the center
+            d("M12 15.5a3.5 3.5 0 1 1 0-7a3.5 3.5 0 0 1 0 7z")
+        }
+    }
+}

--- a/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/icons/TrashIcon.kt
+++ b/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/icons/TrashIcon.kt
@@ -1,0 +1,18 @@
+package com.varabyte.kobweb.silk.components.icons
+
+import androidx.compose.runtime.Composable
+import com.varabyte.kobweb.compose.dom.svg.Path
+import com.varabyte.kobweb.compose.dom.svg.ViewBox
+import com.varabyte.kobweb.compose.ui.Modifier
+import com.varabyte.kobweb.compose.ui.toAttrs
+
+@Composable
+fun TrashIcon(modifier: Modifier = Modifier) {
+    // We use a viewBox of 24x24 and a stroke render style for an outlined icon.
+    createIcon(viewBox = ViewBox(0, 0, 24, 24), renderStyle = IconRenderStyle.Stroke(2), attrs = modifier.toAttrs()) {
+        // This path creates the trash can shape.
+        Path {
+            d("M3 6h18M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2")
+        }
+    }
+}

--- a/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/icons/UploadIcon.kt
+++ b/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/icons/UploadIcon.kt
@@ -1,0 +1,34 @@
+package com.varabyte.kobweb.silk.components.icons
+
+import androidx.compose.runtime.Composable
+import com.varabyte.kobweb.compose.dom.svg.Path
+import com.varabyte.kobweb.compose.dom.svg.ViewBox
+import com.varabyte.kobweb.compose.ui.Modifier
+import com.varabyte.kobweb.compose.ui.toAttrs
+
+@Composable
+fun UploadIcon(modifier: Modifier = Modifier) {
+    createIcon(viewBox = ViewBox(0, 0, 14, 14), renderStyle = IconRenderStyle.Fill(), attrs = modifier.toAttrs()) {
+        Path {
+            d {
+                moveTo(11.2857, 7.94286)
+                lineTo(10.08571, 9.14286)
+                lineTo(7.85714, 6.85214)
+                lineTo(7.85714, 13)
+                lineTo(6.14286, 13)
+                lineTo(6.14286, 6.85214)
+                lineTo(3.91429, 9.14286)
+                lineTo(2.71429, 7.94286)
+                lineTo(7, 3.57143)
+                lineTo(11.2857, 7.94286)
+                closePath()
+                moveTo(1, 2.71429)
+                lineTo(1, 1)
+                lineTo(13, 1)
+                lineTo(13, 2.71429)
+                lineTo(1, 2.71429)
+                closePath()
+            }
+        }
+    }
+}

--- a/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/icons/UserIcon.kt
+++ b/frontend/silk-widgets/src/jsMain/kotlin/com/varabyte/kobweb/silk/components/icons/UserIcon.kt
@@ -1,0 +1,19 @@
+package com.varabyte.kobweb.silk.components.icons
+
+import androidx.compose.runtime.Composable
+import com.varabyte.kobweb.compose.dom.svg.Path
+import com.varabyte.kobweb.compose.dom.svg.ViewBox
+import com.varabyte.kobweb.compose.ui.Modifier
+import com.varabyte.kobweb.compose.ui.toAttrs
+
+@Composable
+fun UserIcon(modifier: Modifier = Modifier) {
+    createIcon(viewBox = ViewBox(0, 0, 24, 24), renderStyle = IconRenderStyle.Stroke(2), attrs = modifier.toAttrs()) {
+        Path {
+            d("M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2")
+        }
+        Path {
+            d("M12 11a4 4 0 1 0 0-8 4 4 0 0 0 0 8z")
+        }
+    }
+}

--- a/playground/site/src/jsMain/kotlin/playground/pages/Widgets.kt
+++ b/playground/site/src/jsMain/kotlin/playground/pages/Widgets.kt
@@ -50,12 +50,19 @@ import com.varabyte.kobweb.silk.components.icons.ArrowForwardIcon
 import com.varabyte.kobweb.silk.components.icons.ArrowUpIcon
 import com.varabyte.kobweb.silk.components.icons.AttachmentIcon
 import com.varabyte.kobweb.silk.components.icons.CheckIcon
+import com.varabyte.kobweb.silk.components.icons.UploadIcon
+import com.varabyte.kobweb.silk.components.icons.CodeIcon
+import com.varabyte.kobweb.silk.components.icons.ClipboardIcon
+import com.varabyte.kobweb.silk.components.icons.UserIcon
 import com.varabyte.kobweb.silk.components.icons.ChevronDownIcon
 import com.varabyte.kobweb.silk.components.icons.ChevronLeftIcon
+import com.varabyte.kobweb.silk.components.icons.SettingsIcon
 import com.varabyte.kobweb.silk.components.icons.ChevronRightIcon
 import com.varabyte.kobweb.silk.components.icons.ChevronUpIcon
 import com.varabyte.kobweb.silk.components.icons.CircleIcon
 import com.varabyte.kobweb.silk.components.icons.CloseIcon
+import com.varabyte.kobweb.silk.components.icons.EditIcon
+import com.varabyte.kobweb.silk.components.icons.TrashIcon
 import com.varabyte.kobweb.silk.components.icons.DownloadIcon
 import com.varabyte.kobweb.silk.components.icons.ExclaimIcon
 import com.varabyte.kobweb.silk.components.icons.HamburgerIcon
@@ -63,8 +70,14 @@ import com.varabyte.kobweb.silk.components.icons.IndeterminateIcon
 import com.varabyte.kobweb.silk.components.icons.InfoIcon
 import com.varabyte.kobweb.silk.components.icons.LightbulbIcon
 import com.varabyte.kobweb.silk.components.icons.MinusIcon
+import com.varabyte.kobweb.silk.components.icons.LockIcon
 import com.varabyte.kobweb.silk.components.icons.MoonIcon
+import com.varabyte.kobweb.silk.components.icons.EyeIcon
+import com.varabyte.kobweb.silk.components.icons.EyeOffIcon
 import com.varabyte.kobweb.silk.components.icons.PlusIcon
+import com.varabyte.kobweb.silk.components.icons.CalendarIcon
+import com.varabyte.kobweb.silk.components.icons.SearchIcon
+import com.varabyte.kobweb.silk.components.icons.CheckCircleIcon
 import com.varabyte.kobweb.silk.components.icons.QuestionIcon
 import com.varabyte.kobweb.silk.components.icons.QuoteIcon
 import com.varabyte.kobweb.silk.components.icons.SquareIcon
@@ -272,18 +285,26 @@ fun WidgetsPage() {
                         "Arrow Up" to { ArrowUpIcon() },
                         "Attachment" to { AttachmentIcon() },
                         "Check" to { CheckIcon() },
+                        "Code" to { CodeIcon() },
                         "Chevron Down" to { ChevronDownIcon() },
                         "Chevron Left" to { ChevronLeftIcon() },
                         "Chevron Right" to { ChevronRightIcon() },
                         "Chevron Up" to { ChevronUpIcon() },
                         "Circle" to { CircleIcon() },
+                        "Check Circle" to { CheckCircleIcon() },
                         "Close" to { CloseIcon() },
+                        "Calendar" to { CalendarIcon() },
+                        "Clipboard" to { ClipboardIcon() },
                         "Download" to { DownloadIcon() },
+                        "Edit" to { EditIcon() },
                         "Exclaim" to { ExclaimIcon() },
+                        "Eye" to { EyeIcon() },
+                        "Eye Off" to { EyeOffIcon() },
                         "Hamburger" to { HamburgerIcon() },
                         "Indeterminate" to { IndeterminateIcon() },
                         "Info" to { InfoIcon() },
                         "Lightbulb" to { LightbulbIcon() },
+                        "Lock" to { LockIcon() },
                         "Minus" to { MinusIcon() },
                         "Moon" to { MoonIcon() },
                         "Plus" to { PlusIcon() },
@@ -292,6 +313,11 @@ fun WidgetsPage() {
                         "Square" to { SquareIcon() },
                         "Stop" to { StopIcon() },
                         "Sun" to { SunIcon() },
+                        "Search" to { SearchIcon() },
+                        "Settings" to { SettingsIcon() },
+                        "Trash" to { TrashIcon() },
+                        "Upload" to { UploadIcon() },
+                        "User" to { UserIcon() },
                         "Warning" to { WarningIcon() },
                     )
 


### PR DESCRIPTION
Adding new SVG icons to the current list for helping developers to efficiently use icons built-in, instead of installing other icons from external sources. Here's the current list with the new icons: 
<img width="724" height="110" alt="481582532-f793005a-30eb-4dfd-9afa-28306d3c15b9" src="https://github.com/user-attachments/assets/1aa5870f-f67e-4467-9758-ef54a48741ce" />
