### PR TITLE
Enable the unused return value checker

### DIFF
--- a/common/client-server-internal/src/commonMain/kotlin/com/varabyte/kobweb/navigation/RouteTree.kt
+++ b/common/client-server-internal/src/commonMain/kotlin/com/varabyte/kobweb/navigation/RouteTree.kt
@@ -353,6 +353,7 @@ class RouteTree<T : Any> {
     /**
      * Register [route] with this tree, or return false if it was already added.
      */
+    @IgnorableReturnValue
     fun register(route: String, data: T): Boolean {
         val routeSegments = route.split('/').toMutableList()
         var currNode: Node<T> = root

--- a/common/kobwebx-frontmatter/src/commonMain/kotlin/com/varabyte/kobwebx/frontmatter/FrontMatterElement.kt
+++ b/common/kobwebx-frontmatter/src/commonMain/kotlin/com/varabyte/kobwebx/frontmatter/FrontMatterElement.kt
@@ -131,16 +131,22 @@ sealed class FrontMatterElement {
         @FrontMatterElementBuilder
         class Builder {
             private var map = mutableMapOf<String, FrontMatterElement>()
+
+            @IgnorableReturnValue
             fun addScalar(key: String, value: String): Builder {
                 map[key] = Scalar(value)
                 return this
             }
+
+            @IgnorableReturnValue
             fun addMap(key: String, populate: Builder.() -> Unit): Builder {
                 val builder = Builder()
                 builder.populate()
                 map[key] = builder.build()
                 return this
             }
+
+            @IgnorableReturnValue
             fun addList(key: String, populate: ValueList.Builder.() -> Unit): Builder {
                 val builder = ValueList.Builder()
                 builder.populate()
@@ -167,10 +173,14 @@ sealed class FrontMatterElement {
         @FrontMatterElementBuilder
         class Builder {
             private var list = mutableListOf<FrontMatterElement>()
+
+            @IgnorableReturnValue
             fun addScalar(value: String): Builder {
                 list.add(Scalar(value))
                 return this
             }
+
+            @IgnorableReturnValue
             fun addMap(populate: ValueMap.Builder.() -> Unit): Builder {
                 val builder = ValueMap.Builder()
                 builder.populate()

--- a/common/kobwebx-frontmatter/src/commonTest/kotlin/com/varabyte/kobwebx/markdown/FrontMatterElementTest.kt
+++ b/common/kobwebx-frontmatter/src/commonTest/kotlin/com/varabyte/kobwebx/markdown/FrontMatterElementTest.kt
@@ -56,10 +56,10 @@ class FrontMatterElementTest {
         assertThat(fmElement["data.assets.font.Roboto"]).isNull()
 
         // Ensure getValue throws or not throws (as expected)
-        fmElement.getValue("title")
-        fmElement.getValue("data.assets.images")
-        fmElement.getValue("data.assets.images.0")
-        fmElement.getValue("data.assets.font")
+        val _ = fmElement.getValue("title")
+        val _ = fmElement.getValue("data.assets.images")
+        val _ = fmElement.getValue("data.assets.images.0")
+        val _ = fmElement.getValue("data.assets.font")
         assertThrows<NoSuchElementException> { fmElement.getValue("data") }
         assertThrows<NoSuchElementException> { fmElement.getValue("data.x.y.z") }
         assertThrows<NoSuchElementException> { fmElement.getValue("data.assets.images.5") }
@@ -87,7 +87,7 @@ class FrontMatterElementTest {
         }
 
         // Values are fine
-        FrontMatterElement.Builder {
+        val _ = FrontMatterElement.Builder {
             addScalar("validKey1", "valid.value")
             addList("validKey2") {
                 addScalar("valid.value")

--- a/frontend/browser-ext/src/jsMain/kotlin/com/varabyte/kobweb/browser/http/Fetch.kt
+++ b/frontend/browser-ext/src/jsMain/kotlin/com/varabyte/kobweb/browser/http/Fetch.kt
@@ -33,7 +33,7 @@ enum class HttpMethod {
  */
 private suspend fun Response.getBodyBytes(): ByteArray {
     return suspendCoroutine { cont ->
-        this.arrayBuffer().then { responseBuffer ->
+        val _ = this.arrayBuffer().then { responseBuffer ->
             val int8Array = Int8Array(responseBuffer)
             cont.resume(ByteArray(int8Array.length) { i -> int8Array[i] })
         }.catch {
@@ -138,7 +138,7 @@ suspend fun Window.fetchBytes(
         requestInitDynamic["signal"] = abortController.signal
     }
 
-    window.fetch(resource, requestInit).then(
+    val _ = window.fetch(resource, requestInit).then(
         onFulfilled = { res ->
             if (res.ok) {
                 res.getBodyBytesAsync { bodyBytes -> responseBytesDeferred.complete(bodyBytes) }

--- a/frontend/browser-ext/src/jsMain/kotlin/com/varabyte/kobweb/browser/util/TimerUtils.kt
+++ b/frontend/browser-ext/src/jsMain/kotlin/com/varabyte/kobweb/browser/util/TimerUtils.kt
@@ -102,6 +102,7 @@ interface CancellableIntervalScope {
  *
  * @return A [CancellableActionHandle] to the action being invoked. Use [CancellableActionHandle.cancel] to cancel the action.
  */
+@IgnorableReturnValue
 fun WindowOrWorkerGlobalScope.invokeLater(block: () -> Unit): CancellableActionHandle {
     return setTimeout(0.milliseconds, block)
 }
@@ -111,6 +112,7 @@ fun WindowOrWorkerGlobalScope.invokeLater(block: () -> Unit): CancellableActionH
  *
  * @return A [CancellableActionHandle] to the action being invoked. Use [CancellableActionHandle.cancel] to cancel the action.
  */
+@IgnorableReturnValue
 fun WindowOrWorkerGlobalScope.setTimeout(timeout: Duration, block: () -> Unit): CancellableActionHandle {
     val id = setTimeout(block, timeout.inWholeMilliseconds.toInt())
     return CancellableActionHandle(id)
@@ -121,6 +123,7 @@ fun WindowOrWorkerGlobalScope.setTimeout(timeout: Duration, block: () -> Unit): 
  *
  * @return A [CancellableActionHandle] to the action being invoked. Use [CancellableActionHandle.cancel] to cancel the action.
  */
+@IgnorableReturnValue
 fun WindowOrWorkerGlobalScope.setInterval(delay: Duration, block: CancellableIntervalScope.() -> Unit): CancellableActionHandle {
     lateinit var cancelHandle: CancellableActionHandle
     val scope = object : CancellableIntervalScope {
@@ -144,6 +147,7 @@ fun WindowOrWorkerGlobalScope.setInterval(delay: Duration, block: CancellableInt
  *
  * @return A [CancellableActionHandle] to the action being invoked. Use [CancellableActionHandle.cancel] to cancel the action.
  */
+@IgnorableReturnValue
 fun WindowOrWorkerGlobalScope.setInterval(initialDelay: Duration, delay: Duration, block: CancellableIntervalScope.() -> Unit): CancellableActionHandle {
     lateinit var cancelHandle: CancellableActionHandle
     val scope = object : CancellableIntervalScope {
@@ -169,6 +173,7 @@ fun WindowOrWorkerGlobalScope.setInterval(initialDelay: Duration, delay: Duratio
  *
  * @return A [CancellableActionHandle] to the action being invoked. Use [CancellableActionHandle.cancel] to cancel the action.
  */
+@IgnorableReturnValue
 fun WindowOrWorkerGlobalScope.invokeThenInterval(delay: Duration, block: CancellableIntervalScope.() -> Unit): CancellableActionHandle {
     var shouldContinueInterval = true
     val scope = object : CancellableIntervalScope {

--- a/frontend/compose-html-ext/src/jsMain/kotlin/com/varabyte/kobweb/compose/css/functions/Gradients.kt
+++ b/frontend/compose-html-ext/src/jsMain/kotlin/com/varabyte/kobweb/compose/css/functions/Gradients.kt
@@ -34,11 +34,21 @@ interface Gradient : CSSStyleValue {
             return entries.toTypedArray()
         }
 
-        fun add(color: CSSColorValue) = entries.add(Entry.Color.Simple(color))
-        fun add(color: CSSColorValue, stop: T) = entries.add(Entry.Color.Stop(color, stop))
-        fun add(color: CSSColorValue, from: T, to: T) = entries.add(Entry.Color.StopRange(color, from, to))
+        fun add(color: CSSColorValue) {
+            entries.add(Entry.Color.Simple(color))
+        }
 
-        fun setMidpoint(hint: T) = entries.add(Entry.Hint(hint))
+        fun add(color: CSSColorValue, stop: T) {
+            entries.add(Entry.Color.Stop(color, stop))
+        }
+
+        fun add(color: CSSColorValue, from: T, to: T) {
+            entries.add(Entry.Color.StopRange(color, from, to))
+        }
+
+        fun setMidpoint(hint: T) {
+            entries.add(Entry.Hint(hint))
+        }
     }
 }
 

--- a/frontend/compose-html-ext/src/jsMain/kotlin/com/varabyte/kobweb/compose/dom/svg/Svg.kt
+++ b/frontend/compose-html-ext/src/jsMain/kotlin/com/varabyte/kobweb/compose/dom/svg/Svg.kt
@@ -312,9 +312,17 @@ interface SvgPointsAttrs<T : SVGElement> : AttrsScope<T> {
 }
 
 interface SvgPresentationAttrs<T : SVGElement> : AttrsScope<T> {
-    fun stroke(value: CSSColorValue) = this.attr("stroke", value.toString())
-    fun stroke(value: SVGStrokeType) = this.attr("stroke", value.toString())
-    fun stroke(id: SvgId) = this.attr("stroke", id.urlReference)
+    fun stroke(value: CSSColorValue) {
+        this.attr("stroke", value.toString())
+    }
+
+    fun stroke(value: SVGStrokeType) {
+        this.attr("stroke", value.toString())
+    }
+
+    fun stroke(id: SvgId) {
+        this.attr("stroke", id.urlReference)
+    }
 
     fun strokeDashArray(vararg values: Number) {
         this.attr("stroke-dasharray", values.joinToString(",") { it.toString() })
@@ -324,34 +332,73 @@ interface SvgPresentationAttrs<T : SVGElement> : AttrsScope<T> {
         this.attr("stroke-dasharray", values.joinToString(",") { it.toString() })
     }
 
-    fun strokeDashOffset(value: Number) = this.attr("stroke-dashoffset", value.toString())
-    fun strokeDashOffset(value: CSSLengthOrPercentageValue) = this.attr("stroke-dashoffset", value.toString())
+    fun strokeDashOffset(value: Number) {
+        this.attr("stroke-dashoffset", value.toString())
+    }
 
-    fun strokeLineCap(value: SVGStrokeLineCap) = this.attr("stroke-linecap", value.toString())
+    fun strokeDashOffset(value: CSSLengthOrPercentageValue) {
+        this.attr("stroke-dashoffset", value.toString())
+    }
 
-    fun strokeLineJoin(value: SVGStrokeLineJoin) = this.attr("stroke-linejoin", value.toString())
+    fun strokeLineCap(value: SVGStrokeLineCap) {
+        this.attr("stroke-linecap", value.toString())
+    }
 
-    fun strokeMiterLimit(value: Number) = this.attr("stroke-miterlimit", value.toString())
+    fun strokeLineJoin(value: SVGStrokeLineJoin) {
+        this.attr("stroke-linejoin", value.toString())
+    }
 
-    fun strokeOpacity(value: Number) = this.attr("stroke-opacity", value.toString())
+    fun strokeMiterLimit(value: Number) {
+        this.attr("stroke-miterlimit", value.toString())
+    }
 
-    fun strokeWidth(value: Number) = this.attr("stroke-width", value.toString())
-    fun strokeWidth(value: CSSLengthOrPercentageValue) = this.attr("stroke-width", value.toString())
+    fun strokeOpacity(value: Number) {
+        this.attr("stroke-opacity", value.toString())
+    }
 
-    fun fill(value: CSSColorValue) = this.attr("fill", value.toString())
-    fun fill(value: SVGFillType) = this.attr("fill", value.toString())
-    fun fill(id: SvgId) = this.attr("fill", id.urlReference)
+    fun strokeWidth(value: Number) {
+        this.attr("stroke-width", value.toString())
+    }
 
-    fun fillRule(value: SVGFillRule) = this.attr("fill-rule", value.toString())
+    fun strokeWidth(value: CSSLengthOrPercentageValue) {
+        this.attr("stroke-width", value.toString())
+    }
 
-    fun fillOpacity(value: Number) = this.attr("fill-opacity", value.toString())
+    fun fill(value: CSSColorValue) {
+        this.attr("fill", value.toString())
+    }
 
-    fun filter(id: SvgId) = this.attr("filter", id.urlReference)
+    fun fill(value: SVGFillType) {
+        this.attr("fill", value.toString())
+    }
 
-    fun floodColor(color: CSSColorValue) = attr("flood-color", color.toString())
-    fun floodOpacity(value: Number) = attr("flood-opacity", value.toString())
+    fun fill(id: SvgId) {
+        this.attr("fill", id.urlReference)
+    }
 
-    fun lightingColor(color: CSSColorValue) = attr("lighting-color", color.toString())
+    fun fillRule(value: SVGFillRule) {
+        this.attr("fill-rule", value.toString())
+    }
+
+    fun fillOpacity(value: Number) {
+        this.attr("fill-opacity", value.toString())
+    }
+
+    fun filter(id: SvgId) {
+        this.attr("filter", id.urlReference)
+    }
+
+    fun floodColor(color: CSSColorValue) {
+        attr("flood-color", color.toString())
+    }
+
+    fun floodOpacity(value: Number) {
+        attr("flood-opacity", value.toString())
+    }
+
+    fun lightingColor(color: CSSColorValue) {
+        attr("lighting-color", color.toString())
+    }
 }
 
 interface SvgPreserveAspectRatioAttrs<T : SVGElement> : AttrsScope<T> {

--- a/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/ui/Modifier.kt
+++ b/frontend/kobweb-compose/src/jsMain/kotlin/com/varabyte/kobweb/compose/ui/Modifier.kt
@@ -72,6 +72,7 @@ fun Modifier.thenUnless(condition: Boolean, other: Modifier): Modifier {
  */
 @OptIn(ExperimentalContracts::class, ExperimentalExtendedContracts::class)
 inline fun Modifier.thenIf(condition: Boolean, lazyProduce: () -> Modifier): Modifier {
+    @Suppress("RETURN_VALUE_NOT_USED") // `holdsIn` is incorrectly not marked as ignorable
     contract { condition holdsIn lazyProduce }
     return this.then(if (condition) lazyProduce() else Modifier)
 }
@@ -88,6 +89,7 @@ inline fun <T> Modifier.thenIfNotNull(value: T?, consume: (T) -> Modifier): Modi
  */
 @OptIn(ExperimentalContracts::class, ExperimentalExtendedContracts::class)
 inline fun Modifier.thenUnless(condition: Boolean, lazyProduce: () -> Modifier): Modifier {
+    @Suppress("RETURN_VALUE_NOT_USED") // `holdsIn` is incorrectly not marked as ignorable
     contract { !condition holdsIn lazyProduce }
     return this.thenIf(!condition, lazyProduce)
 }

--- a/frontend/kobweb-core/src/jsMain/kotlin/com/varabyte/kobweb/navigation/Router.kt
+++ b/frontend/kobweb-core/src/jsMain/kotlin/com/varabyte/kobweb/navigation/Router.kt
@@ -429,6 +429,7 @@ class Router {
      *   abort early, which can be useful if you have additional code you want to run that will do additional
      *   processing.
      */
+    @IgnorableReturnValue
     fun tryRoutingTo(
         pathQueryAndFragment: String,
         updateHistoryMode: UpdateHistoryMode = UpdateHistoryMode.PUSH,

--- a/frontend/kobweb-worker-interface/src/jsMain/kotlin/com/varabyte/kobweb/worker/Attachments.kt
+++ b/frontend/kobweb-worker-interface/src/jsMain/kotlin/com/varabyte/kobweb/worker/Attachments.kt
@@ -134,6 +134,7 @@ class Attachments private constructor(
         private val transferables = mutableMapOf<String, Any>()
         private val metadata = mutableMapOf<String, Any>()
 
+        @IgnorableReturnValue
         private fun MutableMap<String, Any>.add(key: String, type: String, value: Any): Builder {
             if (this.put(suffixedKey(key, type), value) != null) {
                 error("Attachment with key \"$key\" was added twice for the same type ($type).")
@@ -148,20 +149,37 @@ class Attachments private constructor(
         // the Kobweb team if they want us to support any of the missing types.
 
         //        fun add(key: String, value: AudioData) = cloneables.add(key, "AudioData", value)
+        @IgnorableReturnValue
         fun add(key: String, value: Blob) = cloneables.add(key, "Blob", value)
 //        fun add(key: String, value: CropTarget) = cloneables.add(key, "CropTarget", value)
 //        fun add(key: String, value: CryptoKey) = cloneables.add(key, "CryptoKey", value)
+        @IgnorableReturnValue
         fun add(key: String, value: DOMMatrix) = cloneables.add(key, "DOMMatrix", value)
+
+        @IgnorableReturnValue
         fun add(key: String, value: DOMMatrixReadOnly) = cloneables.add(key, "DOMMatrixReadOnly", value)
+
+        @IgnorableReturnValue
         fun add(key: String, value: DOMPoint) = cloneables.add(key, "DOMPoint", value)
+
+        @IgnorableReturnValue
         fun add(key: String, value: DOMPointReadOnly) = cloneables.add(key, "DOMPointReadOnly", value)
+
+        @IgnorableReturnValue
         fun add(key: String, value: DOMQuad) = cloneables.add(key, "DOMQuad", value)
+
+        @IgnorableReturnValue
         fun add(key: String, value: DOMRect) = cloneables.add(key, "DOMRect", value)
+
+        @IgnorableReturnValue
         fun add(key: String, value: DOMRectReadOnly) = cloneables.add(key, "DOMRectReadOnly", value)
 //        fun add(key: String, value: EncodedAudioChunk) = cloneables.add(key, "EncodedAudioChunk", value)
 //        fun add(key: String, value: EncodedVideoChunk) = cloneables.add(key, "EncodedVideoChunk", value)
 //        fun add(key: String, value: FencedFrameConfig) = cloneables.add(key, "FencedFrameConfig", value)
+        @IgnorableReturnValue
         fun add(key: String, value: File) = cloneables.add(key, "File", value)
+
+        @IgnorableReturnValue
         fun add(key: String, value: FileList) = cloneables.add(key, "FileList", value)
 //        fun add(key: String, value: FileSystemDirectoryHandle) = cloneables.add(key, "FileSystemDirectoryHandle", value)
 //        fun add(key: String, value: FileSystemFileHandle) = cloneables.add(key, "FileSystemFileHandle", value)
@@ -179,8 +197,13 @@ class Attachments private constructor(
 
         // region transferables
 
+        @IgnorableReturnValue
         fun add(key: String, value: ArrayBuffer) = transferables.add(key, "ArrayBuffer", value)
+
+        @IgnorableReturnValue
         fun add(key: String, value: MessagePort) = transferables.add(key, "MessagePort", value)
+
+        @IgnorableReturnValue
         fun add(key: String, value: ImageBitmap) = transferables.add(key, "ImageBitmap", value)
         // TODO: There are more official types that are supported, see
         //  https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Transferable_objects#supported_objects
@@ -194,15 +217,34 @@ class Attachments private constructor(
         // These methods allow adding values that themselves are not directly transferable but we can wrap transferable
         // concepts underneath them ourselves for user convenience.
 
+        @IgnorableReturnValue
         fun add(key: String, value: Int8Array) = transferables.add(key, "Int8Array", value.buffer)
+
+        @IgnorableReturnValue
         fun add(key: String, value: Uint8Array) = transferables.add(key, "Uint8Array", value.buffer)
+
+        @IgnorableReturnValue
         fun add(key: String, value: Uint8ClampedArray) = transferables.add(key, "Uint8ClampedArray", value.buffer)
+
+        @IgnorableReturnValue
         fun add(key: String, value: Int16Array) = transferables.add(key, "Int16Array", value.buffer)
+
+        @IgnorableReturnValue
         fun add(key: String, value: Uint16Array) = transferables.add(key, "Uint16Array", value.buffer)
+
+        @IgnorableReturnValue
         fun add(key: String, value: Int32Array) = transferables.add(key, "Int32Array", value.buffer)
+
+        @IgnorableReturnValue
         fun add(key: String, value: Uint32Array) = transferables.add(key, "Uint32Array", value.buffer)
+
+        @IgnorableReturnValue
         fun add(key: String, value: Float32Array) = transferables.add(key, "Float32Array", value.buffer)
+
+        @IgnorableReturnValue
         fun add(key: String, value: Float64Array) = transferables.add(key, "Float64Array", value.buffer)
+
+        @IgnorableReturnValue
         fun add(key: String, value: ImageData) {
             transferables.add(key, "ImageData_buffer", value.data.buffer)
             metadata[suffixedKey(key, "ImageData_width")] = value.width

--- a/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/SilkFoundationStyles.kt
+++ b/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/SilkFoundationStyles.kt
@@ -66,19 +66,20 @@ private fun CustomStyle(styleSheet: CSSRulesHolder) {
 
 // Based on https://github.com/JetBrains/compose-multiplatform/blob/master/html/core/src/jsMain/kotlin/org/jetbrains/compose/web/dom/Style.kt
 
-private fun CSSStyleSheet.clearCSSRules() {
+internal fun CSSStyleSheet.clearCSSRules() {
     repeat(cssRules.length) {
         deleteRule(0)
     }
 }
 
-private fun CSSStyleSheet.setCSSRules(cssRules: CSSRuleDeclarationList) {
+internal fun CSSStyleSheet.setCSSRules(cssRules: CSSRuleDeclarationList) {
     cssRules.forEach { cssRule ->
         addRule(cssRule.customStringPresentation())
     }
 }
 
-private fun CSSStyleSheet.addRule(cssRule: String): CSSRule? {
+@IgnorableReturnValue
+internal fun CSSStyleSheet.addRule(cssRule: String): CSSRule? {
     val cssRuleIndex = this.insertRule(cssRule, this.cssRules.length)
     return this.cssRules.item(cssRuleIndex)
 }

--- a/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/init/SilkStylesheet.kt
+++ b/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/init/SilkStylesheet.kt
@@ -204,7 +204,7 @@ internal object SilkStylesheetInstance : SilkStylesheet {
         }
         styles.forEach { cssStyle -> cssStyle.addStylesInto(siteStyleSheet) }
 
-        keyframes.map { (name, build) ->
+        keyframes.forEach { (name, build) ->
             val lightBuilder = KeyframesBuilder(ColorMode.LIGHT).apply(build)
             val darkBuilder = KeyframesBuilder(ColorMode.DARK).apply(build)
 

--- a/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/style/CssStyle.kt
+++ b/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/style/CssStyle.kt
@@ -435,8 +435,10 @@ internal class SimpleCssStyle(
     extraModifier: @Composable () -> Modifier,
     val layer: String?
 ) : CssStyle<GeneralKind>(init, extraModifier) {
-    internal fun addStylesInto(styleSheet: StyleSheet): ClassSelectors {
-        return addStylesInto(selector, styleSheet, layer)
+    internal fun addStylesInto(styleSheet: StyleSheet) {
+        // Ignore the returned selectors as `SimpleCssStyle` wraps `stylesheet.registerStyle(...)` rules which are
+        // never applied to an element via `toModifier()`.
+        val _ = addStylesInto(selector, styleSheet, layer)
     }
 }
 

--- a/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/style/CssStyleVariant.kt
+++ b/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/style/CssStyleVariant.kt
@@ -52,6 +52,7 @@ inline fun <K : ComponentKind> CssStyleVariant<K>.thenIf(
     condition: Boolean,
     produce: () -> CssStyleVariant<K>
 ): CssStyleVariant<K> {
+    @Suppress("RETURN_VALUE_NOT_USED") // `holdsIn` is incorrectly not marked as ignorable
     contract { condition holdsIn produce }
     return if (condition) this.then(produce()) else this
 }
@@ -61,6 +62,7 @@ inline fun <K : ComponentKind> CssStyleVariant<K>.thenUnless(
     condition: Boolean,
     produce: () -> CssStyleVariant<K>
 ): CssStyleVariant<K> {
+    @Suppress("RETURN_VALUE_NOT_USED") // `holdsIn` is incorrectly not marked as ignorable
     contract { !condition holdsIn produce }
     return this.thenIf(!condition, produce)
 }

--- a/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/style/breakpoint/BreakpointConditions.kt
+++ b/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/style/breakpoint/BreakpointConditions.kt
@@ -4,9 +4,10 @@ import androidx.compose.runtime.*
 import com.varabyte.kobweb.compose.dom.GenericTag
 import com.varabyte.kobweb.compose.ui.Modifier
 import com.varabyte.kobweb.compose.ui.modifiers.*
+import com.varabyte.kobweb.silk.addRule
+import com.varabyte.kobweb.silk.clearCSSRules
 import org.jetbrains.compose.web.css.*
 import org.w3c.dom.HTMLStyleElement
-import org.w3c.dom.css.CSSRule
 import org.w3c.dom.css.CSSStyleSheet
 
 private fun CSSMediaQuery.invert(): CSSMediaQuery {
@@ -61,17 +62,6 @@ internal fun SilkBreakpointDisplayStyles() {
                 cssStylesheet?.clearCSSRules()
             }
         }
-    }
-}
-
-private fun CSSStyleSheet.addRule(cssRule: String): CSSRule? {
-    val cssRuleIndex = this.insertRule(cssRule, this.cssRules.length)
-    return this.cssRules.item(cssRuleIndex)
-}
-
-private fun CSSStyleSheet.clearCSSRules() {
-    repeat(cssRules.length) {
-        deleteRule(0)
     }
 }
 

--- a/gradle/build-logic/publish/src/main/kotlin/com/varabyte/kobweb/gradle/publish/KobwebPublishPlugin.kt
+++ b/gradle/build-logic/publish/src/main/kotlin/com/varabyte/kobweb/gradle/publish/KobwebPublishPlugin.kt
@@ -9,8 +9,8 @@ import org.gradle.api.tasks.TaskContainer
 import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.named
-import org.gradle.kotlin.dsl.register
-import org.jetbrains.dokka.gradle.tasks.DokkaGenerateTask
+import org.jetbrains.kotlin.gradle.dsl.HasConfigurableKotlinCompilerOptions
+import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 import javax.inject.Inject
 
 abstract class KobwebPublicationConfig @Inject constructor(objects: ObjectFactory) {
@@ -84,6 +84,11 @@ class KobwebPublishPlugin : Plugin<Project> {
             apply("org.jetbrains.dokka")
             apply("com.vanniktech.maven.publish")
         }
+
+        // Opt in published artifacts to unused return value checker
+        // See: https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0412-unused-return-value-checker.md#opting-in-your-library
+        (project.kotlinExtension as HasConfigurableKotlinCompilerOptions<*>)
+            .compilerOptions.freeCompilerArgs.add("-Xreturn-value-checker=full")
 
         project.configureDokka()
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ ktor = "3.3.3"
 logback = "1.5.15"
 playwright = "1.55.0"
 shadow = "9.1.0"
-truthish = "1.0.3"
+truthish = "1.0.4"
 vanniktech-publish = "0.34.0"
 
 [libraries]

--- a/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/templates/MainTemplate.kt
+++ b/tools/gradle-plugins/application/src/main/kotlin/com/varabyte/kobweb/gradle/application/templates/MainTemplate.kt
@@ -50,6 +50,16 @@ fun createMainFunction(
     val frontendData = appFrontendData.frontendData
     val fileBuilder = FileSpec.builder("", "main").indent(" ".repeat(4))
 
+
+    // We don't want users to get compiler warnings coming from generated code, e.g. harmless unused return values from
+    // @InitSilk fun updateTheme(ctx: InitSilkContext) = ctx.config.apply { ... }
+    fileBuilder.addAnnotation(
+        AnnotationSpec.builder(Suppress::class)
+            .addMember("%S", "RETURN_VALUE_NOT_USED")
+            .addMember("%S", "RETURN_VALUE_NOT_USED_COERCION")
+            .build()
+    )
+
     buildSet {
         val defaultImports = listOf(
             "$KOBWEB_GROUP.core.AppGlobals",

--- a/tools/ksp/site-processors/src/main/kotlin/com/varabyte/kobweb/ksp/frontend/FrontendProcessor.kt
+++ b/tools/ksp/site-processors/src/main/kotlin/com/varabyte/kobweb/ksp/frontend/FrontendProcessor.kt
@@ -55,9 +55,7 @@ import com.varabyte.kobweb.project.frontend.InitSilkEntry
 import com.varabyte.kobweb.project.frontend.KeyframesEntry
 import com.varabyte.kobweb.project.frontend.LayoutEntry
 import com.varabyte.kobweb.project.frontend.assertValid
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import kotlin.collections.firstOrNull
 
 @OptIn(KspExperimental::class)
 class FrontendProcessor(
@@ -738,6 +736,7 @@ class FrontendProcessor(
 
     private fun reportErrorIfLayoutCycleDetected() {
         // Detect cycles in layout dependencies
+        @IgnorableReturnValue
         fun detectLayoutCycle(
             decl: KSFunctionDeclaration,
             path: MutableList<KSFunctionDeclaration> = mutableListOf(),
@@ -766,7 +765,7 @@ class FrontendProcessor(
             }
 
             return layoutsFor[decl]?.let { parentLayout ->
-                val hasChildCycle = detectLayoutCycle(layoutsFor[decl]!!.method, path, errorCtx)
+                val hasChildCycle = detectLayoutCycle(parentLayout.method, path, errorCtx)
                 path.removeLast()
                 hasChildCycle
             } ?: false


### PR DESCRIPTION
In the process, mark ignorable functions and adjust some functions to no longer return unnecessary values.

Notably, this also resolves https://github.com/varabyte/kobweb-intellij-plugin/issues/4 (for users that enable the feature).

Note that while the checker is experimental, it is safe to use in libraries:
> You can freely switch between compiler modes. Despite the feature being experimental, Kotlin metadata for it is compatible in both ways, and using Full mode does not force the compiler to emit pre-release binaries. Compiling your library in Full mode does not cause any problems for users with the feature disabled.

See: https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0412-unused-return-value-checker.md#opting-in-your-library