### PR TITLE
Adjust error message for illegal attributes modifier

### DIFF
--- a/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/style/StyleScope.kt
+++ b/frontend/silk-foundation/src/jsMain/kotlin/com/varabyte/kobweb/silk/style/StyleScope.kt
@@ -182,9 +182,11 @@ internal fun CssModifier.assertNoAttributes(selectorName: String, lazyExtraConte
         appendLine("Details:")
 
         append("\tCSS rule: ")
-        append("\"$selectorName")
-        if (mediaQuery != null) append(mediaQuery)
+        append("\"")
+        if (mediaQuery != null) append("@media $mediaQuery { ")
+        append(selectorName)
         if (suffix != null) append(suffix)
+        if (mediaQuery != null) append(" }")
         appendLine("\"")
         appendLine("\tAttribute(s): ${attrsScope.attributes.keys.joinToString(", ") { "\"$it\"" }}")
         appendLine()


### PR DESCRIPTION
As an example,
Before: `div(min-width: 48rem):hover`
After: `@media (min-width: 48rem) { div:hover }`