### PR TITLE
Add support for multiple headers with same key

### DIFF
--- a/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/http/Headers.kt
+++ b/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/http/Headers.kt
@@ -12,7 +12,7 @@ package com.varabyte.kobweb.api.http
  *
  * @see <a href="https://www.rfc-editor.org/rfc/rfc9110.html#section-5">HTTP Semantics Section 5</a>
  */
-interface Headers {
+interface Headers : Iterable<Pair<String, List<String>>> {
     /**
      * Gets all present header field names
      */
@@ -62,6 +62,10 @@ class MutableHeaders() : Headers {
 
     override fun contains(name: String): Boolean {
         return headers.containsKey(name.lowercase())
+    }
+
+    override fun iterator(): Iterator<Pair<String, List<String>>> {
+        return headers.entries.map { it.key to it.value.toList() }.iterator()
     }
 
     /**

--- a/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/http/Headers.kt
+++ b/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/http/Headers.kt
@@ -1,0 +1,90 @@
+package com.varabyte.kobweb.api.http
+
+class Headers : MutableMap<String, String> {
+    private val headers: MutableMap<String, MutableList<String>> = mutableMapOf()
+
+    // For backwards compatibility reasons
+    // can be removed, once deprecated functions below are removed
+    private val singleValueHeaders: Map<String, String>
+        get() = headers
+            .mapValues { it.value.firstOrNull() }
+            .filterValues { it != null }
+            .mapValues { it.value as String }
+
+    @Deprecated("DO NOT IGNORE. Please change to `tryOptionsBytes` instead. This method will be removed soon in a backwards incompatible way.", replaceWith = ReplaceWith("names"))
+    override val keys: MutableSet<String>
+        get() = names.toMutableSet()
+    @Deprecated("DO NOT IGNORE. Please change to `values(<name>)` instead. This method will be removed soon in a backwards incompatible way.", replaceWith = ReplaceWith("values('name')"))
+    override val values: MutableCollection<String>
+        get() = singleValueHeaders.values.toMutableList()
+    @Deprecated("DO NOT IGNORE. This method will be removed soon in a backwards incompatible way.")
+    override val entries: MutableSet<MutableMap.MutableEntry<String, String>>
+        get() = singleValueHeaders.toMutableMap().entries
+
+    val names: Set<String>
+        get() = headers.keys
+
+    @Deprecated("DO NOT IGNORE. Please change to `append` instead. This method will be removed soon in a backwards incompatible way.", replaceWith = ReplaceWith("append"))
+    override fun put(key: String, value: String): String? {
+        val existingValue = singleValueHeaders[key]
+        headers[key]?.clear()
+        append(key, value)
+        return existingValue
+    }
+
+    @Deprecated("DO NOT IGNORE. This method will be removed soon in a backwards incompatible way.")
+    override fun remove(key: String): String? {
+        return headers.remove(key)?.firstOrNull()
+    }
+
+    @Deprecated("DO NOT IGNORE. This method will be removed soon in a backwards incompatible way.")
+    override fun putAll(from: Map<out String, String>) {
+        from.forEach { (key, value) -> put(key, value) }
+    }
+
+    @Deprecated("DO NOT IGNORE. This method will be removed soon in a backwards incompatible way.")
+    override fun clear() {
+        headers.clear()
+    }
+
+    @Deprecated("DO NOT IGNORE. This method will be removed soon in a backwards incompatible way.")
+    override val size: Int
+        get() = singleValueHeaders.size
+
+    @Deprecated("DO NOT IGNORE. This method will be removed soon in a backwards incompatible way.")
+    override fun isEmpty(): Boolean {
+        return singleValueHeaders.isEmpty()
+    }
+
+    @Deprecated("DO NOT IGNORE. Please change to `contains` instead. This method will be removed soon in a backwards incompatible way.", replaceWith = ReplaceWith("contains"))
+    override fun containsKey(key: String): Boolean {
+        return contains(key)
+    }
+
+    @Deprecated("DO NOT IGNORE. This method will be removed soon in a backwards incompatible way.")
+    override fun containsValue(value: String): Boolean {
+        return singleValueHeaders.containsValue(value)
+    }
+
+    override operator fun get(key: String): String? {
+        return headers[key]?.firstOrNull()
+    }
+
+    @Deprecated("DO NOT IGNORE. Please change to `append` instead. This method will be removed soon in a backwards incompatible way.", replaceWith = ReplaceWith("append"))
+    operator fun set(key: String, value: String) {
+        put(key, value)
+    }
+
+    fun contains(name: String): Boolean {
+        return headers.containsKey(name)
+    }
+
+    fun values(name: String): List<String> {
+        return headers.getOrDefault(name, emptyList())
+    }
+
+    fun append(name: String, value: String) {
+        headers.getOrPut(name) { mutableListOf() }.add(value)
+    }
+
+}

--- a/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/http/Headers.kt
+++ b/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/http/Headers.kt
@@ -34,8 +34,20 @@ interface Headers {
     fun contains(name: String): Boolean
 }
 
-class MutableHeaders : Headers {
+class MutableHeaders() : Headers {
     private val headers: MutableMap<String, MutableList<String>> = mutableMapOf()
+
+    constructor(headers: Headers) : this() {
+        headers.names.forEach { name ->
+            headers.values(name).forEach { value -> append(name, value) }
+        }
+    }
+
+    constructor(headers: Map<String, List<String>>) : this() {
+        headers.entries.forEach { entry ->
+            entry.value.forEach { value -> append(entry.key, value) }
+        }
+    }
 
     override val names: Set<String>
         get() = headers.keys
@@ -52,6 +64,9 @@ class MutableHeaders : Headers {
         return headers.containsKey(name.lowercase())
     }
 
+    /**
+     * Appends a header value associated with the given name
+     */
     fun append(name: String, value: String) {
         headers.getOrPut(name.lowercase()) { mutableListOf() }.add(value)
     }

--- a/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/http/Headers.kt
+++ b/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/http/Headers.kt
@@ -1,25 +1,59 @@
 package com.varabyte.kobweb.api.http
 
-class Headers {
+/**
+ * A collection of HTTP header values.
+ *
+ * In a majority of cases, HTTP headers are normally a collection of simple key/value pairs,
+ * but per official spec, a header field can technically contain multiple values. As a result,
+ * users are expected to [append] new values, not simply set them.
+ *
+ * Also, according to the RFC, header field names are case-insensitive. In other words, accessing
+ * "Content-Type" is functionally identical to "content-type".
+ *
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc9110.html#section-5">HTTP Semantics Section 5</a>
+ */
+interface Headers {
+    /**
+     * Gets all present header field names
+     */
+    val names: Set<String>
+
+    /**
+     * Gets first value from the list of values associated with the given name, or null if the name is not present
+     */
+    operator fun get(key: String): String?
+
+    /**
+     * Gets all entries associated with the given name
+     */
+    fun values(name: String): List<String>
+
+    /**
+     * Checks if a header field with the given name exists
+     */
+    fun contains(name: String): Boolean
+}
+
+class MutableHeaders : Headers {
     private val headers: MutableMap<String, MutableList<String>> = mutableMapOf()
 
-    val names: Set<String>
+    override val names: Set<String>
         get() = headers.keys
 
-    operator fun get(key: String): String? {
-        return headers[key]?.firstOrNull()
+    override operator fun get(key: String): String? {
+        return headers[key.lowercase()]?.firstOrNull()
     }
 
-    fun contains(name: String): Boolean {
-        return headers.containsKey(name)
+    override fun values(name: String): List<String> {
+        return headers.getOrDefault(name.lowercase(), emptyList())
     }
 
-    fun values(name: String): List<String> {
-        return headers.getOrDefault(name, emptyList())
+    override fun contains(name: String): Boolean {
+        return headers.containsKey(name.lowercase())
     }
 
     fun append(name: String, value: String) {
-        headers.getOrPut(name) { mutableListOf() }.add(value)
+        headers.getOrPut(name.lowercase()) { mutableListOf() }.add(value)
     }
 
 }

--- a/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/http/Headers.kt
+++ b/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/http/Headers.kt
@@ -11,7 +11,7 @@ class Headers : MutableMap<String, String> {
             .filterValues { it != null }
             .mapValues { it.value as String }
 
-    @Deprecated("DO NOT IGNORE. Please change to `tryOptionsBytes` instead. This method will be removed soon in a backwards incompatible way.", replaceWith = ReplaceWith("names"))
+    @Deprecated("DO NOT IGNORE. Please change to `names` instead. This method will be removed soon in a backwards incompatible way.", replaceWith = ReplaceWith("names"))
     override val keys: MutableSet<String>
         get() = names.toMutableSet()
     @Deprecated("DO NOT IGNORE. Please change to `values(<name>)` instead. This method will be removed soon in a backwards incompatible way.", replaceWith = ReplaceWith("values('name')"))

--- a/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/http/Headers.kt
+++ b/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/http/Headers.kt
@@ -13,9 +13,7 @@ package com.varabyte.kobweb.api.http
  * @see <a href="https://www.rfc-editor.org/rfc/rfc9110.html#section-5">HTTP Semantics Section 5</a>
  */
 interface Headers : Iterable<Pair<String, List<String>>> {
-    /**
-     * Gets all present header field names
-     */
+
     val names: Set<String>
 
     /**
@@ -28,9 +26,6 @@ interface Headers : Iterable<Pair<String, List<String>>> {
      */
     fun values(name: String): List<String>
 
-    /**
-     * Checks if a header field with the given name exists
-     */
     fun contains(name: String): Boolean
 }
 

--- a/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/http/Headers.kt
+++ b/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/http/Headers.kt
@@ -5,7 +5,7 @@ package com.varabyte.kobweb.api.http
  *
  * In a majority of cases, HTTP headers are normally a collection of simple key/value pairs,
  * but per official spec, a header field can technically contain multiple values. As a result,
- * users are expected to [append] new values, not simply set them.
+ * users are able to [append] new values, besides simply [set] them.
  *
  * Also, according to the RFC, header field names are case-insensitive. In other words, accessing
  * "Content-Type" is functionally identical to "content-type".
@@ -69,6 +69,15 @@ class MutableHeaders() : Headers {
      */
     fun append(name: String, value: String) {
         headers.getOrPut(name.lowercase()) { mutableListOf() }.add(value)
+    }
+
+    /**
+     * Sets a single value associated with the given name
+     *
+     * Use [append] if the value should be added to the list of values instead
+     */
+    operator fun set(name: String, value: String) {
+        headers[name.lowercase()] = mutableListOf(value)
     }
 
 }

--- a/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/http/Headers.kt
+++ b/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/http/Headers.kt
@@ -1,78 +1,13 @@
 package com.varabyte.kobweb.api.http
 
-class Headers : MutableMap<String, String> {
+class Headers {
     private val headers: MutableMap<String, MutableList<String>> = mutableMapOf()
-
-    // For backwards compatibility reasons
-    // can be removed, once deprecated functions below are removed
-    private val singleValueHeaders: Map<String, String>
-        get() = headers
-            .mapValues { it.value.firstOrNull() }
-            .filterValues { it != null }
-            .mapValues { it.value as String }
-
-    @Deprecated("DO NOT IGNORE. Please change to `names` instead. This method will be removed soon in a backwards incompatible way.", replaceWith = ReplaceWith("names"))
-    override val keys: MutableSet<String>
-        get() = names.toMutableSet()
-    @Deprecated("DO NOT IGNORE. Please change to `values(<name>)` instead. This method will be removed soon in a backwards incompatible way.", replaceWith = ReplaceWith("values('name')"))
-    override val values: MutableCollection<String>
-        get() = singleValueHeaders.values.toMutableList()
-    @Deprecated("DO NOT IGNORE. This method will be removed soon in a backwards incompatible way.")
-    override val entries: MutableSet<MutableMap.MutableEntry<String, String>>
-        get() = singleValueHeaders.toMutableMap().entries
 
     val names: Set<String>
         get() = headers.keys
 
-    @Deprecated("DO NOT IGNORE. Please change to `append` instead. This method will be removed soon in a backwards incompatible way.", replaceWith = ReplaceWith("append"))
-    override fun put(key: String, value: String): String? {
-        val existingValue = singleValueHeaders[key]
-        headers[key]?.clear()
-        append(key, value)
-        return existingValue
-    }
-
-    @Deprecated("DO NOT IGNORE. This method will be removed soon in a backwards incompatible way.")
-    override fun remove(key: String): String? {
-        return headers.remove(key)?.firstOrNull()
-    }
-
-    @Deprecated("DO NOT IGNORE. This method will be removed soon in a backwards incompatible way.")
-    override fun putAll(from: Map<out String, String>) {
-        from.forEach { (key, value) -> put(key, value) }
-    }
-
-    @Deprecated("DO NOT IGNORE. This method will be removed soon in a backwards incompatible way.")
-    override fun clear() {
-        headers.clear()
-    }
-
-    @Deprecated("DO NOT IGNORE. This method will be removed soon in a backwards incompatible way.")
-    override val size: Int
-        get() = singleValueHeaders.size
-
-    @Deprecated("DO NOT IGNORE. This method will be removed soon in a backwards incompatible way.")
-    override fun isEmpty(): Boolean {
-        return singleValueHeaders.isEmpty()
-    }
-
-    @Deprecated("DO NOT IGNORE. Please change to `contains` instead. This method will be removed soon in a backwards incompatible way.", replaceWith = ReplaceWith("contains"))
-    override fun containsKey(key: String): Boolean {
-        return contains(key)
-    }
-
-    @Deprecated("DO NOT IGNORE. This method will be removed soon in a backwards incompatible way.")
-    override fun containsValue(value: String): Boolean {
-        return singleValueHeaders.containsValue(value)
-    }
-
-    override operator fun get(key: String): String? {
+    operator fun get(key: String): String? {
         return headers[key]?.firstOrNull()
-    }
-
-    @Deprecated("DO NOT IGNORE. Please change to `append` instead. This method will be removed soon in a backwards incompatible way.", replaceWith = ReplaceWith("append"))
-    operator fun set(key: String, value: String) {
-        put(key, value)
     }
 
     fun contains(name: String): Boolean {

--- a/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/http/Request.kt
+++ b/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/http/Request.kt
@@ -45,7 +45,7 @@ interface Request {
      */
     val queryParams: Map<String, String>
     /** All headers sent with the request. */
-    val headers: Map<String, List<String>>
+    val headers: Headers
     /**
      * Any cookies sent with the request.
      *
@@ -119,7 +119,7 @@ class MutableRequest(
     override var method: HttpMethod,
     params: Map<String, String>,
     queryParams: Map<String, String>,
-    headers: Map<String, List<String>>,
+    headers: Headers,
     cookies: Map<String, String>,
     override var body: Body?,
     override val data: MutableData = MutableData(),
@@ -137,9 +137,7 @@ class MutableRequest(
 
     override val params: MutableMap<String, String> = params.toMutableMap()
     override val queryParams: MutableMap<String, String> = queryParams.toMutableMap()
-    override val headers: MutableMap<String, MutableList<String>> = headers
-        .mapValues { entry -> entry.value.toMutableList() }
-        .toMutableMap()
+    override val headers: MutableHeaders = MutableHeaders(headers)
 
     override val cookies: MutableMap<String, String> = cookies.toMutableMap()
 }

--- a/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/http/Response.kt
+++ b/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/http/Response.kt
@@ -55,7 +55,7 @@ class Response {
     /**
      * Any additional headers to send back to the client.
      */
-    val headers = mutableMapOf<String, String>()
+    val headers = Headers()
 
     /**
      * A holder of user data that can be added to this response.
@@ -90,6 +90,7 @@ fun Response.setBodyText(text: String) {
 fun Response.setAsRedirect(newPath: String, status: Int = 307, isApiPath: Boolean = false) {
     check(status in VALID_REDIRECT_STATUS_CODES) { "Redirect status code is invalid ($status); must be one of $VALID_REDIRECT_STATUS_CODES" }
     this.status = status
-    headers["Location"] =
+    val location =
         if (!isApiPath || newPath.startsWith(API_PREFIX_WITH_TRAILING_SLASH)) newPath else "$API_PREFIX$newPath"
+    headers.append("Location", location)
 }

--- a/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/http/Response.kt
+++ b/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/http/Response.kt
@@ -90,7 +90,6 @@ fun Response.setBodyText(text: String) {
 fun Response.setAsRedirect(newPath: String, status: Int = 307, isApiPath: Boolean = false) {
     check(status in VALID_REDIRECT_STATUS_CODES) { "Redirect status code is invalid ($status); must be one of $VALID_REDIRECT_STATUS_CODES" }
     this.status = status
-    val location =
+    headers["Location"] =
         if (!isApiPath || newPath.startsWith(API_PREFIX_WITH_TRAILING_SLASH)) newPath else "$API_PREFIX$newPath"
-    headers.append("Location", location)
 }

--- a/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/http/Response.kt
+++ b/backend/kobweb-api/src/main/kotlin/com/varabyte/kobweb/api/http/Response.kt
@@ -55,7 +55,7 @@ class Response {
     /**
      * Any additional headers to send back to the client.
      */
-    val headers = Headers()
+    val headers = MutableHeaders()
 
     /**
      * A holder of user data that can be added to this response.

--- a/backend/server/src/main/kotlin/com/varabyte/kobweb/server/plugins/Routing.kt
+++ b/backend/server/src/main/kotlin/com/varabyte/kobweb/server/plugins/Routing.kt
@@ -263,8 +263,8 @@ private suspend fun RoutingContext.handleApiCall(
         )
         try {
             val response = apiJar.apis.handle("/$pathStr", request)
-            response.headers.forEach { (key, value) ->
-                call.response.headers.append(key, value)
+            response.headers.names.forEach { name ->
+                response.headers.values(name).forEach { value -> call.response.headers.append(name, value) }
             }
             val body = response.body?.takeIf { httpMethod != HttpMethod.HEAD }
             @OptIn(DelicateApi::class)

--- a/backend/server/src/main/kotlin/com/varabyte/kobweb/server/plugins/Routing.kt
+++ b/backend/server/src/main/kotlin/com/varabyte/kobweb/server/plugins/Routing.kt
@@ -6,6 +6,7 @@ import com.varabyte.kobweb.api.http.Body
 import com.varabyte.kobweb.api.http.ContentDisposition
 import com.varabyte.kobweb.api.http.HttpMethod
 import com.varabyte.kobweb.api.http.Multipart
+import com.varabyte.kobweb.api.http.MutableHeaders
 import com.varabyte.kobweb.api.http.MutableRequest
 import com.varabyte.kobweb.api.http.Request
 import com.varabyte.kobweb.api.log.Logger
@@ -248,7 +249,7 @@ private suspend fun RoutingContext.handleApiCall(
             .flattenEntries()
             .toMap()
 
-        val headers = call.request.headers.entries().associate { it.key to it.value }
+        val headers = MutableHeaders(call.request.headers.entries().associate { it.key to it.value })
         val request = MutableRequest(
             Request.Connection(
                 origin = call.request.origin.toRequestConnectionDetails(),

--- a/backend/server/src/main/kotlin/com/varabyte/kobweb/server/plugins/Routing.kt
+++ b/backend/server/src/main/kotlin/com/varabyte/kobweb/server/plugins/Routing.kt
@@ -264,8 +264,8 @@ private suspend fun RoutingContext.handleApiCall(
         )
         try {
             val response = apiJar.apis.handle("/$pathStr", request)
-            response.headers.names.forEach { name ->
-                response.headers.values(name).forEach { value -> call.response.headers.append(name, value) }
+            response.headers.forEach { (name, values) ->
+                values.forEach { value -> call.response.headers.append(name, value) }
             }
             val body = response.body?.takeIf { httpMethod != HttpMethod.HEAD }
             @OptIn(DelicateApi::class)


### PR DESCRIPTION
Related Issue: #776 

- Add support for multiple header entries with same name for api responses in the backend

## Breaking changes

- The api for `headers` within `Response` on the server changed from `MutableMap<String, String>` to the new interface `Headers`

## Additional Notes
- The client api is unchanged: Since the fetch api doesn't allow multiple header entries with the same key, the current implementation seems sufficient to me

