### PR TITLE
feat: Add configurable rate limiting to Kobweb server

### DIFF
--- a/backend/server/src/main/kotlin/com/varabyte/kobweb/server/Application.kt
+++ b/backend/server/src/main/kotlin/com/varabyte/kobweb/server/Application.kt
@@ -14,6 +14,7 @@ import com.varabyte.kobweb.server.api.SiteLayout
 import com.varabyte.kobweb.server.io.ServerStateFile
 import com.varabyte.kobweb.server.plugin.KobwebServerPlugin
 import com.varabyte.kobweb.server.plugins.configureHTTP
+import com.varabyte.kobweb.server.plugins.configureRateLimiting
 import com.varabyte.kobweb.server.plugins.configureRouting
 import com.varabyte.kobweb.server.plugins.configureSerialization
 import io.ktor.server.application.*
@@ -77,8 +78,8 @@ suspend fun main() {
         System.setProperty(
             "LOG_MAX_HISTORY",
             maxFileCount?.takeIf { it > 0 }?.toString()
-                // Note: The "9999" hack value below used to be Int.MAX_VALUE, but this caused logback to break,
-                // consuming 100% of the thread. ~30 years (9999 days) of logs should be enough for anyone.
+            // Note: The "9999" hack value below used to be Int.MAX_VALUE, but this caused logback to break,
+            // consuming 100% of the thread. ~30 years (9999 days) of logs should be enough for anyone.
                 ?: if (totalSizeCap?.takeIf { it.inWholeBytes > 0 } == null) "0" else "9999")
         System.setProperty("LOG_SIZE_CAP", totalSizeCap?.inWholeBytes?.toString() ?: "0")
     }
@@ -123,6 +124,7 @@ suspend fun main() {
     val engine = embeddedServer(Netty, port) {
         log.info("Initializing server engine for Kobweb project \"${conf.site.title}\"")
 
+        configureRateLimiting(conf.server.rateLimiting)
         configureRouting(appProperties, env, siteLayout, conf, globals, events)
         configureSerialization()
         configureHTTP(appProperties, env, conf)
@@ -161,6 +163,7 @@ suspend fun main() {
                         globals.status.clear() // If we happen to be showing a message when paused, cancel it!
                     }
                 }
+
                 is ServerRequest.ResumeClientEvents -> {
                     if (pausedCopy != null) {
                         globals.set(pausedCopy)
@@ -168,9 +171,11 @@ suspend fun main() {
                         pausedCopy = null
                     }
                 }
+
                 is ServerRequest.IncrementVersion -> {
                     targetGlobals().version++
                 }
+
                 is ServerRequest.SetStatus -> {
                     targetGlobals().status.apply {
                         text = request.message

--- a/backend/server/src/main/kotlin/com/varabyte/kobweb/server/plugins/RateLimiting.kt
+++ b/backend/server/src/main/kotlin/com/varabyte/kobweb/server/plugins/RateLimiting.kt
@@ -1,0 +1,112 @@
+package com.varabyte.kobweb.server.plugins
+
+import com.varabyte.kobweb.common.error.KobwebException
+import com.varabyte.kobweb.project.conf.Server
+import com.varabyte.kobweb.server.ratelimiting.FixedWindowAlgorithm
+import com.varabyte.kobweb.server.ratelimiting.RateLimitingAlgorithm
+import com.varabyte.kobweb.server.ratelimiting.TokenBucketAlgorithm
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.ApplicationCallPipeline
+import io.ktor.server.application.ApplicationStopped
+import io.ktor.server.application.call
+import io.ktor.server.application.log
+import io.ktor.server.plugins.origin
+import io.ktor.server.request.uri
+import io.ktor.server.response.respond
+import kotlin.math.ceil
+
+private fun Server.RateLimiting.Configuration.toAlgorithm(): RateLimitingAlgorithm {
+    return when (this) {
+        is Server.RateLimiting.Configuration.TokenBucket -> TokenBucketAlgorithm(this)
+        is Server.RateLimiting.Configuration.FixedWindow -> FixedWindowAlgorithm(this)
+    }
+}
+
+private fun ApplicationCall.resolveKey(algorithm: RateLimitingAlgorithm): String {
+    fun resolveKey(key: Server.RateLimiting.Key, customHeader: String): String {
+        return when (key) {
+            Server.RateLimiting.Key.IP -> request.origin.remoteAddress
+            Server.RateLimiting.Key.FORWARD_IP -> {
+                request.headers[HttpHeaders.XForwardedFor]
+                    ?.split(',')
+                    ?.firstOrNull()
+                    ?.trim()
+            }
+
+            Server.RateLimiting.Key.CUSTOM_HEADER -> request.headers[customHeader]
+        } ?: request.local.remoteAddress
+    }
+
+    return when (algorithm) {
+        is TokenBucketAlgorithm -> {
+            resolveKey(
+                key = algorithm.configuration.key,
+                customHeader = algorithm.configuration.customHeader
+            )
+        }
+
+        is FixedWindowAlgorithm -> {
+            resolveKey(
+                key = algorithm.configuration.key,
+                customHeader = algorithm.configuration.customHeader
+            )
+        }
+
+        else -> throw KobwebException("Unsupported rate limiting algorithm: $algorithm")
+    }
+}
+
+fun Application.configureRateLimiting(rateLimiting: Server.RateLimiting) {
+    val logger = log
+
+    if (!rateLimiting.enabled) {
+        logger.info("Rate limiting is disabled, skipping configuration")
+        return
+    }
+
+    val globalAlgorithm = rateLimiting.global.toAlgorithm()
+
+    val routeAlgorithms = rateLimiting.routes
+        .sortedByDescending { it.path.length }
+        .map { route -> route.path to route.configuration.toAlgorithm() }
+
+    intercept(ApplicationCallPipeline.Plugins) {
+        val path = call.request.uri.substringBefore("?")
+
+        val algorithm = routeAlgorithms.firstOrNull { (currentPath, _) ->
+            path.startsWith(currentPath)
+        }?.second ?: globalAlgorithm
+
+        val key = call.resolveKey(algorithm)
+
+        val result = algorithm.consume(key)
+
+        call.response.headers.append(name = "X-RateLimit-Limit", value = result.limit.toString())
+        call.response.headers.append(name = "X-RateLimit-Remaining", value = result.remaining.toString())
+        call.response.headers.append(name = "X-RateLimit-Reset", value = (result.resetsAtMs / 1000).toString())
+
+        if (!result.allowed) {
+            call.response.headers.append(
+                name = HttpHeaders.RetryAfter,
+                value = ceil(result.retryAfterMs / 1000.0).toLong().toString()
+            )
+
+            logger.debug("Rate limited: key={}, path={}, retryAfter={}ms", key, path, result.retryAfterMs)
+
+            call.respond(HttpStatusCode.TooManyRequests)
+
+            finish()
+        }
+    }
+
+    monitor.subscribe(ApplicationStopped) {
+        globalAlgorithm.close()
+
+        routeAlgorithms.forEach { (_, algorithm) ->
+            algorithm.close()
+        }
+    }
+}

--- a/backend/server/src/main/kotlin/com/varabyte/kobweb/server/ratelimiting/FixedWindowAlgorithm.kt
+++ b/backend/server/src/main/kotlin/com/varabyte/kobweb/server/ratelimiting/FixedWindowAlgorithm.kt
@@ -1,0 +1,134 @@
+package com.varabyte.kobweb.server.ratelimiting
+
+import com.varabyte.kobweb.project.conf.Server
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration.Companion.milliseconds
+
+private const val CLEANUP_INTERVAL_MULTIPLIER = 10
+
+/**
+ * A concurrent implementation of the Fixed Window rate-limiting algorithm.
+ *
+ * Time is divided into discrete, non-overlapping windows of [duration][Server.RateLimiting.Configuration.FixedWindow.duration].
+ * Each window allows up to [size][Server.RateLimiting.Configuration.FixedWindow.size] requests per client.
+ * When the current window expires, the counter resets.
+ *
+ * Window boundaries are computed from epoch time via integer division (`nowMs / durationMs`), so all clients
+ * share the same window boundaries for a given duration.
+ *
+ * @param configuration The parameters controlling the window size and duration.
+ */
+class FixedWindowAlgorithm(val configuration: Server.RateLimiting.Configuration.FixedWindow) :
+    RateLimitingAlgorithm {
+
+    private val closed = AtomicBoolean(false)
+
+    private val durationMs = configuration.duration.inWholeMilliseconds
+
+    /**
+     * The state of a single client's request counter within its current window.
+     *
+     * @property id The window identifier, computed as `System.currentTimeMillis() / durationMs`.
+     * When the current time advances past this window, the counter resets.
+     * @property count The number of requests made within this window.
+     */
+    private class WindowState(
+        var id: Long,
+        var count: Int,
+    )
+
+    private val states = ConcurrentHashMap<String, WindowState>()
+
+    private val coroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+    init {
+        require(configuration.size > 0) { "size must be positive, was ${configuration.size}" }
+        require(durationMs > 0) { "duration must be positive, was ${configuration.duration}" }
+
+        coroutineScope.launch {
+            val cleanUpIntervalMs = durationMs * CLEANUP_INTERVAL_MULTIPLIER
+
+            while (isActive) {
+                delay(cleanUpIntervalMs.milliseconds)
+
+                val nowMs = System.currentTimeMillis()
+
+                val currentId = nowMs / durationMs
+
+                states.forEach { (key, _) ->
+                    states.compute(key) { _, state ->
+                        if (state == null) return@compute null
+                        if (state.id < currentId) null else state
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Attempts to consume a request slot for the given client identifier.
+     *
+     * If the current window still has capacity, the request is allowed and the counter is incremented.
+     * If the window is exhausted, the request is rejected with a retry-after hint.
+     *
+     * @param key The unique identifier for the client (e.g., an IP address).
+     * @return A [RateLimitingResult] indicating whether the request is allowed and metadata for the response headers.
+     */
+    override fun consume(key: String): RateLimitingResult {
+        check(!closed.get()) { "Algorithm has been closed" }
+
+        lateinit var result: RateLimitingResult
+
+        states.compute(key) { _, current ->
+            val nowMs = System.currentTimeMillis()
+
+            val currentId = nowMs / durationMs
+            val resetsAtMs = (currentId + 1) * durationMs
+
+            val state = current ?: WindowState(id = currentId, count = 0)
+
+            if (state.id != currentId) {
+                state.id = currentId
+                state.count = 0
+            }
+
+            if (state.count < configuration.size) {
+                state.count++
+
+                result = RateLimitingResult(
+                    allowed = true,
+                    retryAfterMs = 0,
+                    limit = configuration.size,
+                    remaining = configuration.size - state.count,
+                    resetsAtMs = resetsAtMs
+                )
+            } else {
+                result = RateLimitingResult(
+                    allowed = false,
+                    retryAfterMs = resetsAtMs - nowMs,
+                    limit = configuration.size,
+                    remaining = 0,
+                    resetsAtMs = resetsAtMs
+                )
+            }
+
+            state
+        }
+
+        return result
+    }
+
+    override fun close() {
+        if (!closed.compareAndSet(false, true)) return
+        coroutineScope.cancel()
+        states.clear()
+    }
+}

--- a/backend/server/src/main/kotlin/com/varabyte/kobweb/server/ratelimiting/RateLimitingAlgorithm.kt
+++ b/backend/server/src/main/kotlin/com/varabyte/kobweb/server/ratelimiting/RateLimitingAlgorithm.kt
@@ -1,0 +1,28 @@
+package com.varabyte.kobweb.server.ratelimiting
+
+/**
+ * Represents the result of a rate limiting check.
+ *
+ * @property allowed Whether the request is permitted.
+ * @property retryAfterMs The number of milliseconds the client should wait before retrying.
+ *   This is `0` when [allowed] is `true`.
+ * @property limit The maximum number of requests allowed within the rate limiting window.
+ * @property remaining The number of requests remaining within the current window.
+ * @property resetsAtMs The wall-clock timestamp (epoch millis) at which the rate limit window resets.
+ */
+data class RateLimitingResult(
+    val allowed: Boolean,
+    val retryAfterMs: Long,
+    val limit: Int,
+    val remaining: Int,
+    val resetsAtMs: Long,
+)
+
+/** Algorithm for rate limiting requests. */
+interface RateLimitingAlgorithm : AutoCloseable {
+    /** Check if a request for the given key is allowed. */
+    fun consume(key: String): RateLimitingResult
+
+    /** Closes the rate limiter to new requests and cleans up resources. */
+    override fun close()
+}

--- a/backend/server/src/main/kotlin/com/varabyte/kobweb/server/ratelimiting/TokenBucketAlgorithm.kt
+++ b/backend/server/src/main/kotlin/com/varabyte/kobweb/server/ratelimiting/TokenBucketAlgorithm.kt
@@ -1,0 +1,157 @@
+package com.varabyte.kobweb.server.ratelimiting
+
+import com.varabyte.kobweb.project.conf.Server
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.math.ceil
+import kotlin.math.floor
+import kotlin.math.min
+import kotlin.time.Duration.Companion.nanoseconds
+
+private const val CLEANUP_INTERVAL_MULTIPLIER = 10
+
+/**
+ * A concurrent implementation of the Token Bucket rate-limiting algorithm.
+ *
+ * Each client identified by a key is assigned a [Bucket] which contains a number of tokens.
+ *
+ * Each incoming request consumes one token from the bucket and its
+ * [tokens][Bucket.tokens] are replenished periodically at the rate of
+ * [configuration][Server.RateLimiting.Configuration.TokenBucket]'s
+ * [tokens][Server.RateLimiting.Configuration.TokenBucket.tokens] per
+ * [duration][Server.RateLimiting.Configuration.TokenBucket.duration].
+ *
+ * @param configuration The parameters controlling the bucket's capacity, refill rate, and duration.
+ */
+class TokenBucketAlgorithm(val configuration: Server.RateLimiting.Configuration.TokenBucket) :
+    RateLimitingAlgorithm {
+
+    private val closed = AtomicBoolean(false)
+
+    private val capacity = configuration.capacity
+    private val refillDurationNs = configuration.duration.inWholeNanoseconds
+    private val durationMs = configuration.duration.inWholeMilliseconds
+
+    /**
+     * Stores the internal token state for a single client.
+     *
+     * @property tokens The current number of available tokens in the bucket. This is represented
+     * as a `Double` to support fractional token accumulation during fractional time intervals.
+     *
+     * @property lastRefillNs The `System.nanoTime()` timestamp of the last time tokens were calculated and added.
+     *
+     * @property lastAccessedNs The `System.nanoTime()` timestamp of the last time this bucket was accessed
+     * via [consume]. Used by the background cleanup coroutine to detect and evict idle buckets.
+     */
+    private class Bucket(
+        var tokens: Double,
+        var lastRefillNs: Long,
+        var lastAccessedNs: Long,
+    )
+
+    private val buckets = ConcurrentHashMap<String, Bucket>()
+
+    private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+    init {
+        require(configuration.capacity > 0) { "capacity must be positive, was ${configuration.capacity}" }
+        require(configuration.tokens > 0) { "tokens must be positive, was ${configuration.tokens}" }
+        require(durationMs > 0) { "duration must be positive, was ${configuration.duration}" }
+
+        coroutineScope.launch {
+            val cleanUpIntervalNs = (durationMs * CLEANUP_INTERVAL_MULTIPLIER) * 1_000_000L
+
+            while (isActive) {
+                delay(cleanUpIntervalNs.nanoseconds)
+
+                val now = System.nanoTime()
+
+                buckets.keys.forEach { key ->
+                    buckets.compute(key) { _, bucket ->
+                        if (bucket == null) return@compute null
+
+                        val elapsed = now - bucket.lastRefillNs
+                        val intervals = elapsed.toDouble() / refillDurationNs
+                        val newTokens = intervals * configuration.tokens
+                        val projectedTokens = min(bucket.tokens + newTokens, capacity.toDouble())
+
+                        val isIdle = (now - bucket.lastAccessedNs) >= cleanUpIntervalNs
+
+                        if (projectedTokens >= capacity && isIdle) null else bucket
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Attempts to consume a token for the given client identifier.
+     *
+     * @param key The unique identifier for the client (e.g., an IP address).
+     * @return A [RateLimitingResult] indicating whether the request is allowed and metadata for the response headers.
+     */
+    override fun consume(key: String): RateLimitingResult {
+        check(!closed.get()) { "Algorithm has been closed" }
+
+        lateinit var result: RateLimitingResult
+
+        buckets.compute(key) { _, current ->
+            val nowNs = System.nanoTime()
+            val nowMs = System.currentTimeMillis()
+
+            val bucket = current ?: Bucket(
+                tokens = capacity.toDouble(),
+                lastRefillNs = nowNs,
+                lastAccessedNs = nowNs,
+            )
+
+            val elapsed = nowNs - bucket.lastRefillNs
+            val intervals = elapsed.toDouble() / refillDurationNs
+            val newTokens = intervals * configuration.tokens
+
+            bucket.tokens = min(bucket.tokens + newTokens, capacity.toDouble())
+            bucket.lastRefillNs = nowNs
+            bucket.lastAccessedNs = nowNs
+
+            if (bucket.tokens >= 1.0) {
+                bucket.tokens--
+
+                result = RateLimitingResult(
+                    allowed = true,
+                    retryAfterMs = 0,
+                    limit = capacity,
+                    remaining = floor(bucket.tokens).toInt(),
+                    resetsAtMs = nowMs + durationMs
+                )
+            } else {
+                val retryAfterMs =
+                    ceil((1.0 - bucket.tokens) / configuration.tokens * durationMs).toLong()
+
+                result = RateLimitingResult(
+                    allowed = false,
+                    retryAfterMs = retryAfterMs,
+                    limit = capacity,
+                    remaining = 0,
+                    resetsAtMs = nowMs + retryAfterMs
+                )
+            }
+
+            bucket
+        }
+
+        return result
+    }
+
+    override fun close() {
+        if (!closed.compareAndSet(false, true)) return
+        coroutineScope.cancel()
+        buckets.clear()
+    }
+}

--- a/common/kobweb-common/build.gradle.kts
+++ b/common/kobweb-common/build.gradle.kts
@@ -12,10 +12,10 @@ dependencies {
     // kobweb-common and your own different version of kaml can result in runtime exceptions, so just expose this one.
     api(libs.kaml)
     implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.serialization.json)
 
     testImplementation(kotlin("test"))
     testImplementation(libs.truthish)
-    testImplementation(libs.kotlinx.serialization.json)
 }
 
 kobwebPublication {

--- a/common/kobweb-common/build.gradle.kts
+++ b/common/kobweb-common/build.gradle.kts
@@ -12,10 +12,10 @@ dependencies {
     // kobweb-common and your own different version of kaml can result in runtime exceptions, so just expose this one.
     api(libs.kaml)
     implementation(libs.kotlinx.coroutines.core)
-    implementation(libs.kotlinx.serialization.json)
 
     testImplementation(kotlin("test"))
     testImplementation(libs.truthish)
+    testImplementation(libs.kotlinx.serialization.json)
 }
 
 kobwebPublication {

--- a/common/kobweb-common/src/main/kotlin/com/varabyte/kobweb/common/yaml/YamlExtensions.kt
+++ b/common/kobweb-common/src/main/kotlin/com/varabyte/kobweb/common/yaml/YamlExtensions.kt
@@ -1,5 +1,6 @@
 package com.varabyte.kobweb.common.yaml
 
+import com.charleskorn.kaml.PolymorphismStyle
 import com.charleskorn.kaml.Yaml
 import com.charleskorn.kaml.YamlConfiguration
 
@@ -10,6 +11,9 @@ private val NonStrictYamlInstance by lazy {
             // user tries to pull down a new Kobweb project with an older version the Kobweb binary, we will fail to
             // parse it EVEN IF the field we added didn't really matter that much.
             strictMode = false,
+            // Use a property-based discriminator (e.g., "type: TOKEN_BUCKET") for sealed class polymorphism,
+            // instead of YAML tags (e.g., "!TOKEN_BUCKET"), which is far more intuitive for user-facing config.
+            polymorphismStyle = PolymorphismStyle.Property,
         )
     )
 }

--- a/common/kobweb-common/src/main/kotlin/com/varabyte/kobweb/project/conf/KobwebConf.kt
+++ b/common/kobweb-common/src/main/kotlin/com/varabyte/kobweb/project/conf/KobwebConf.kt
@@ -10,6 +10,7 @@ import com.varabyte.kobweb.common.time.DurationSerializer
 import com.varabyte.kobweb.common.yaml.nonStrictDefault
 import com.varabyte.kobweb.project.KobwebFolder
 import com.varabyte.kobweb.project.io.KobwebReadableTextFile
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import kotlin.time.Duration
@@ -36,6 +37,7 @@ class Server(
     val cors: Cors = Cors(),
     val redirects: List<Redirect> = emptyList(),
     val streaming: Streaming = Streaming(),
+    val rateLimiting: RateLimiting = RateLimiting(),
     val nativeLibraries: List<NativeLibrary> = emptyList(),
 ) {
     /**
@@ -222,6 +224,104 @@ class Server(
             require(name == "*" || schemes.isNotEmpty()) {
                 "Invalid host configuration values. Either the hostname should be '*' or at least one scheme should be specified."
             }
+        }
+    }
+
+    /**
+     * Configuration for Rate Limiting.
+     *
+     * Rate limiting helps protect the server from abuse, brute-force attacks, and unhandled bursts of traffic.
+     * By default, rate limiting is disabled. When enabled, requests are filtered by the provided [global] configuration
+     * and optionally overridden on a per-route basis via [routes].
+     *
+     * @param enabled Set to true to enable rate limiting.
+     * @param global The default rate limiting configuration applied to all routes unless overridden.
+     * @param routes A list of route-specific configurations that override the global configuration.
+     */
+    @Serializable
+    class RateLimiting(
+        val enabled: Boolean = false,
+        val global: Configuration = Configuration.TokenBucket(),
+        val routes: List<RouteConfiguration> = emptyList(),
+    ) {
+        /**
+         * A route-specific override for rate limiting.
+         *
+         * @param path The route path prefix (e.g., "/api/") where this configuration applies.
+         * @param configuration The rate limiting settings specific to this route.
+         */
+        @Serializable
+        class RouteConfiguration(
+            val path: String,
+            val configuration: Configuration,
+        )
+
+        /**
+         * The strategy and configuration used to limit requests.
+         *
+         * See [TokenBucket] and [FixedWindow] for available algorithms.
+         *
+         * The concrete subclass is selected by a `type` discriminator property in the YAML configuration
+         * (e.g. `type: TOKEN_BUCKET` or `type: FIXED_WINDOW`).
+         */
+        @Serializable
+        sealed class Configuration {
+            /** The strategy used to identify the client for rate limiting. */
+            abstract val key: Key
+
+            /**
+             * The Token Bucket algorithm configuration.
+             *
+             * A bucket is given a maximum [capacity]. Every [duration], [tokens] are added to the bucket (up to [capacity]).
+             * Each request consumes one token. If the bucket is empty, the request is rejected.
+             *
+             * @param key The identifier strategy for requests.
+             * @param capacity The maximum number of requests allowed in a burst.
+             * @param tokens The number of tokens added to the bucket per interval.
+             * @param duration The interval at which new tokens are added (e.g. "1s", "500ms").
+             * @param customHeader The HTTP header to inspect for rate limiting when using [Key.CUSTOM_HEADER].
+             */
+            @Serializable
+            @SerialName("TOKEN_BUCKET")
+            class TokenBucket(
+                override val key: Key = Key.IP,
+                val capacity: Int = 100,
+                val tokens: Int = 10,
+                val duration: Duration = 1.seconds,
+                val customHeader: String = "X-Api-Key",
+            ) : Configuration()
+
+            /**
+             * The Fixed Window algorithm configuration.
+             *
+             * Time is divided into discrete windows of [duration]. Within each window, a maximum of [size] requests
+             * are allowed. When the window resets, the counter resets.
+             *
+             * @param key The identifier strategy for requests.
+             * @param size The maximum number of requests allowed per window.
+             * @param duration The duration of the window (e.g. "1s", "500ms").
+             * @param customHeader The HTTP header to inspect for rate limiting when using [Key.CUSTOM_HEADER].
+             */
+            @Serializable
+            @SerialName("FIXED_WINDOW")
+            class FixedWindow(
+                override val key: Key = Key.IP,
+                val size: Int = 100,
+                val duration: Duration = 1.seconds,
+                val customHeader: String = "X-Api-Key",
+            ) : Configuration()
+        }
+
+        /** Key to identify client requests. */
+        enum class Key {
+            /** Use the direct connection IP to identify the request. */
+            IP,
+
+            /** Use the first value in the X-Forwarded-For header to identify the request. */
+            FORWARD_IP,
+
+            /** Use a custom header to identify the request. */
+            CUSTOM_HEADER
         }
     }
 }


### PR DESCRIPTION
Hi @bitspittle,

This PR introduces a configurable rate-limiting system to the Kobweb backend server to help protect endpoints from abuse.
 
By default, rate limiting is disabled, ensuring full backwards compatibility. When enabled, developers can define both a global configuration and specific route-level overrides directly via `conf.yaml`.

The currently supported algorithms are Token Bucket and Fixed Window with the possibility of adding more configurable algorithms.

## Example Configuration (`conf.yaml`)
```yaml
server:
  rateLimiting:
    enabled: true
    global:
      type: TOKEN_BUCKET
      key: FORWARD_IP
      capacity: 100
      tokens: 10
      duration: 1s
    routes:
      - path: /api/sensitive
        configuration:
          type: FIXED_WINDOW
          key: IP
          size: 5
          duration: 1s
          
I would appreciate your feedback on this.